### PR TITLE
Update codex binary discovery logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple dispatcher for running the bundled Codex binary over multiple files in pa
 ## Usage
 
 ```
-python dispatch.py TEMPLATE DATA_DIR OUTPUT_DIR WORKERS [-C WORK_DIR]
+python dispatch.py TEMPLATE DATA_DIR OUTPUT_DIR WORKERS [-C WORK_DIR] [--codex-bin PATH]
 ```
 
 - `TEMPLATE` - path to the prompt template.
@@ -13,5 +13,7 @@ python dispatch.py TEMPLATE DATA_DIR OUTPUT_DIR WORKERS [-C WORK_DIR]
 - `OUTPUT_DIR` - directory where results will be written.
 - `WORKERS` - number of parallel workers.
 - `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current directory.
+- `--codex-bin` - path to the codex binary. If not provided, the script looks for
+  `codex` in `PATH` and then searches the current directory.
 
 Each file in `DATA_DIR` is appended to the template and sent to Codex. The result for a file named `example.txt` will be written to `OUTPUT_DIR/example.txt-codex`.


### PR DESCRIPTION
## Summary
- search for `codex` in PATH by default
- fall back to searching the current directory for an executable containing `codex` in its name
- allow specifying a custom binary via `--codex-bin`
- document the new command line option

## Testing
- `python -m py_compile dispatch.py`


------
https://chatgpt.com/codex/tasks/task_e_68716866fd2883249073122bae2bcd02