### PR TITLE
Implement tree mode for codex dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ Simple dispatcher for running the bundled Codex binary over multiple files in pa
 
 ```
 python dispatch.py TEMPLATE DATA_DIR OUTPUT_DIR WORKERS [-C WORK_DIR] [--codex-bin PATH]
+python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] OUTPUT_DIR WORKERS [--recursive/--no-recursive] [-C WORK_DIR] [--codex-bin PATH]
 ```
 
 - `TEMPLATE` - path to the prompt template.
-- `DATA_DIR` - directory containing input files.
+- `DATA_DIR` - directory containing input files (flat mode).
+- `--tree-dirs` - one or more directories to recursively walk (tree mode).
 - `OUTPUT_DIR` - directory where results will be written.
 - `WORKERS` - number of parallel workers.
-- `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current directory.
+- `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current directory. In tree mode the work directory defaults to each file's parent.
+- `--recursive` / `--no-recursive` - control whether tree mode walks subdirectories (default: recursive).
 - `--codex-bin` - path to the codex binary. If not provided, the script looks for
   `codex` in `PATH` and then searches the current directory.
 
-Each file in `DATA_DIR` is appended to the template and sent to Codex. The result for a file named `example.txt` will be written to `OUTPUT_DIR/example.txt-codex`.
+In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results for a file named `example.txt` will be written to `OUTPUT_DIR/example.txt-codex`.

--- a/dispatch.py
+++ b/dispatch.py
@@ -10,12 +10,37 @@ import shutil
 """Dispatch tool for running Codex on multiple input files in parallel."""
 
 
+def collect_files(dirs: list[str], recursive: bool = True) -> list[str]:
+    files: list[str] = []
+    for root in dirs:
+        if recursive:
+            for dirpath, _, filenames in os.walk(root):
+                for name in filenames:
+                    path = os.path.join(dirpath, name)
+                    if os.path.isfile(path):
+                        files.append(path)
+        else:
+            for name in os.listdir(root):
+                path = os.path.join(root, name)
+                if os.path.isfile(path):
+                    files.append(path)
+    return sorted(files)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("template", help="path to prompt template")
-    parser.add_argument("data_dir", help="directory containing input files")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("data_dir", nargs="?", help="directory containing input files")
+    group.add_argument("--tree-dirs", nargs="+", dest="tree_dirs", help="directories to recursively walk")
     parser.add_argument("output_dir", help="directory for codex outputs")
     parser.add_argument("workers", type=int, help="number of parallel workers")
+    parser.add_argument(
+        "--recursive",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="recursively walk tree directories",
+    )
     parser.add_argument(
         "-C",
         "--work-dir",
@@ -35,7 +60,6 @@ def main() -> None:
     args = parse_args()
 
     template_path = args.template
-    data_dir = args.data_dir
     output_dir = args.output_dir
     workers = args.workers
 
@@ -80,6 +104,7 @@ def main() -> None:
                 data = f.read()
             prompt = template + "\n" + data
             output_path = os.path.join(output_dir, os.path.basename(path) + "-codex")
+            work_dir = os.path.dirname(path) if args.tree_dirs else args.work_dir
             cmd = [
                 codex_bin,
                 "exec",
@@ -88,15 +113,35 @@ def main() -> None:
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--skip-git-repo-check",
                 "-C",
-                args.work_dir,
+                work_dir,
             ]
-            logging.info("Running codex on %s", path)
+            if args.tree_dirs:
+                root = next(
+                    (
+                        d
+                        for d in args.tree_dirs
+                        if os.path.commonpath([os.path.abspath(path), os.path.abspath(d)])
+                        == os.path.abspath(d)
+                    ),
+                    os.path.dirname(path),
+                )
+                logging.info("TreeMode: root=%s   file=%s   work_dir=%s", root, path, work_dir)
+            else:
+                logging.info("Running codex on %s", path)
             subprocess.run(cmd, input=prompt.encode(), check=True)
             logging.info("Wrote %s", output_path)
         except Exception as exc:
             logging.error("Failed processing %s: %s", path, exc)
 
-    files = [os.path.join(data_dir, f) for f in os.listdir(data_dir) if os.path.isfile(os.path.join(data_dir, f))]
+    if args.tree_dirs:
+        files = collect_files(args.tree_dirs, recursive=args.recursive)
+    else:
+        data_dir = args.data_dir
+        files = [
+            os.path.join(data_dir, f)
+            for f in os.listdir(data_dir)
+            if os.path.isfile(os.path.join(data_dir, f))
+        ]
     with ThreadPoolExecutor(max_workers=workers) as executor:
         list(executor.map(run_on_file, files))
 


### PR DESCRIPTION
## Summary
- add `--tree-dirs` option with optional recursion support
- allow collecting files from directories recursively
- set working directory per file in tree mode and log additional info
- update README with tree mode instructions

## Testing
- `python -m py_compile dispatch.py`
- `python dispatch.py -h`

------
https://chatgpt.com/codex/tasks/task_e_6887ebe213f48324aa0603e6abec0b53