### PR TITLE
Fix CLI flag for data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Simple dispatcher for running the bundled Codex binary over multiple files in pa
 ## Usage
 
 ```
-python dispatch.py TEMPLATE DATA_DIR OUTPUT_DIR WORKERS [-C WORK_DIR] [--codex-bin PATH]
+python dispatch.py TEMPLATE --data-dir DIR OUTPUT_DIR WORKERS [-C WORK_DIR] [--codex-bin PATH]
 python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] OUTPUT_DIR WORKERS [--recursive/--no-recursive] [-C WORK_DIR] [--codex-bin PATH]
 ```
 
 - `TEMPLATE` - path to the prompt template.
-- `DATA_DIR` - directory containing input files (flat mode).
+- `--data-dir` - directory containing input files (flat mode).
 - `--tree-dirs` - one or more directories to recursively walk (tree mode).
 - `OUTPUT_DIR` - directory where results will be written.
 - `WORKERS` - number of parallel workers.

--- a/dispatch.py
+++ b/dispatch.py
@@ -31,8 +31,17 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("template", help="path to prompt template")
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("data_dir", nargs="?", help="directory containing input files")
-    group.add_argument("--tree-dirs", nargs="+", dest="tree_dirs", help="directories to recursively walk")
+    group.add_argument(
+        "--data-dir",
+        dest="data_dir",
+        help="directory containing input files",
+    )
+    group.add_argument(
+        "--tree-dirs",
+        nargs="+",
+        dest="tree_dirs",
+        help="directories to recursively walk",
+    )
     parser.add_argument("output_dir", help="directory for codex outputs")
     parser.add_argument("workers", type=int, help="number of parallel workers")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- use `--data-dir` option instead of a positional argument for flat mode
- update README to match

## Testing
- `python dispatch.py --help | head -n 20`
- `python -m py_compile dispatch.py`


------
https://chatgpt.com/codex/tasks/task_e_6887ee0a36448324a7e1af3d37d6a8c3