### PR TITLE
Improve tree mode output and CLI UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] OUTPUT_DIR WORKERS [--recu
 - `--codex-bin` - path to the codex binary. If not provided, the script looks for
   `codex` in `PATH` and then searches the current directory.
 
-In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results for a file named `example.txt` will be written to `OUTPUT_DIR/example.txt-codex`.
+In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results mirror the source tree: a file `src/example.txt` will produce `OUTPUT_DIR/src/example.txt-codex`. This avoids collisions when different directories contain files with the same name.
+
+**Note**: Because `--tree-dirs` consumes the following arguments, place it after the required `OUTPUT_DIR` and `WORKERS` positionals or separate them with `--` when invoking the script.

--- a/dispatch.py
+++ b/dispatch.py
@@ -72,6 +72,9 @@ def main() -> None:
     output_dir = args.output_dir
     workers = args.workers
 
+    if args.data_dir and not args.recursive:
+        logging.warning("--recursive option is ignored when using --data-dir")
+
     with open(template_path, 'r') as f:
         template = f.read()
 
@@ -112,7 +115,25 @@ def main() -> None:
             with open(path, "r") as f:
                 data = f.read()
             prompt = template + "\n" + data
-            output_path = os.path.join(output_dir, os.path.basename(path) + "-codex")
+
+            if args.tree_dirs:
+                root = next(
+                    (
+                        d
+                        for d in args.tree_dirs
+                        if os.path.commonpath([os.path.abspath(path), os.path.abspath(d)])
+                        == os.path.abspath(d)
+                    ),
+                    os.path.dirname(path),
+                )
+                prefix = os.path.basename(root)
+                rel_path = os.path.join(prefix, os.path.relpath(path, root))
+            else:
+                rel_path = os.path.basename(path)
+
+            output_path = os.path.join(output_dir, rel_path + "-codex")
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
             work_dir = os.path.dirname(path) if args.tree_dirs else args.work_dir
             cmd = [
                 codex_bin,
@@ -125,15 +146,6 @@ def main() -> None:
                 work_dir,
             ]
             if args.tree_dirs:
-                root = next(
-                    (
-                        d
-                        for d in args.tree_dirs
-                        if os.path.commonpath([os.path.abspath(path), os.path.abspath(d)])
-                        == os.path.abspath(d)
-                    ),
-                    os.path.dirname(path),
-                )
                 logging.info("TreeMode: root=%s   file=%s   work_dir=%s", root, path, work_dir)
             else:
                 logging.info("Running codex on %s", path)


### PR DESCRIPTION
## Summary
- maintain directory layout in output to avoid name collisions
- warn when --recursive is passed with --data-dir
- clarify README usage for tree mode

## Testing
- `python -m py_compile dispatch.py`
- `python dispatch.py -h | head -n 30`
- `python dispatch.py template.txt output 2 --tree-dirs test_data/src test_data/tests --codex-bin ./fake_codex` *(custom test)*
- `python dispatch.py template.txt --data-dir test_data/src output 1 --no-recursive --codex-bin ./fake_codex` *(custom test)*

------
https://chatgpt.com/codex/tasks/task_e_6887ef28e6d08324b424e7dbb23fbfc7