### PR TITLE
Improve codex dispatch UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Simple dispatcher for running the bundled Codex binary over multiple files in pa
 ## Usage
 
 ```
-python dispatch.py TEMPLATE --data-dir DIR OUTPUT_DIR WORKERS [-C WORK_DIR] [--codex-bin PATH]
-python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] OUTPUT_DIR WORKERS [--recursive/--no-recursive] [-C WORK_DIR] [--codex-bin PATH]
+python dispatch.py TEMPLATE --data-dir DIR --output-dir OUT --workers N [-C WORK_DIR] [--codex-bin PATH]
+python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] --output-dir OUT --workers N [--recursive/--no-recursive] [-C WORK_DIR] [--codex-bin PATH]
 ```
 
 - `TEMPLATE` - path to the prompt template.
 - `--data-dir` - directory containing input files (flat mode).
 - `--tree-dirs` - one or more directories to recursively walk (tree mode).
-- `OUTPUT_DIR` - directory where results will be written.
-- `WORKERS` - number of parallel workers.
+- `--output-dir` - directory where results will be written.
+- `--workers` - number of parallel workers.
 - `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current directory. In tree mode the work directory defaults to each file's parent.
 - `--recursive` / `--no-recursive` - control whether tree mode walks subdirectories (default: recursive).
 - `--codex-bin` - path to the codex binary. If not provided, the script looks for
@@ -21,4 +21,4 @@ python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] OUTPUT_DIR WORKERS [--recu
 
 In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results mirror the source tree: a file `src/example.txt` will produce `OUTPUT_DIR/src/example.txt-codex`. This avoids collisions when different directories contain files with the same name.
 
-**Note**: Because `--tree-dirs` consumes the following arguments, place it after the required `OUTPUT_DIR` and `WORKERS` positionals or separate them with `--` when invoking the script.
+With `--output-dir` and `--workers` provided as options, arguments can be specified in any order.

--- a/dispatch.py
+++ b/dispatch.py
@@ -42,8 +42,19 @@ def parse_args() -> argparse.Namespace:
         dest="tree_dirs",
         help="directories to recursively walk",
     )
-    parser.add_argument("output_dir", help="directory for codex outputs")
-    parser.add_argument("workers", type=int, help="number of parallel workers")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        required=True,
+        help="directory for codex outputs",
+    )
+    parser.add_argument(
+        "-j",
+        "--workers",
+        type=int,
+        required=True,
+        help="number of parallel workers",
+    )
     parser.add_argument(
         "--recursive",
         action=argparse.BooleanOptionalAction,
@@ -75,10 +86,16 @@ def main() -> None:
     if args.data_dir and not args.recursive:
         logging.warning("--recursive option is ignored when using --data-dir")
 
-    with open(template_path, 'r') as f:
+    with open(template_path, "r") as f:
         template = f.read()
 
     os.makedirs(output_dir, exist_ok=True)
+
+    root_prefix: dict[str, str] = {}
+    if args.tree_dirs:
+        for idx, d in enumerate(args.tree_dirs, 1):
+            base = os.path.basename(os.path.normpath(d))
+            root_prefix[os.path.abspath(d)] = f"{idx}_{base}"
 
     codex_bin = args.codex_bin
     if codex_bin:
@@ -103,17 +120,19 @@ def main() -> None:
                 )
                 sys.exit(1)
             else:
-                logging.error(
-                    "Codex binary not found in PATH or current directory"
-                )
+                logging.error("Codex binary not found in PATH or current directory")
                 sys.exit(1)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     def run_on_file(path: str) -> None:
         try:
-            with open(path, "r") as f:
-                data = f.read()
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+            except UnicodeDecodeError:
+                logging.warning("Skipping non-text file %s", path)
+                return
             prompt = template + "\n" + data
 
             if args.tree_dirs:
@@ -121,15 +140,17 @@ def main() -> None:
                     (
                         d
                         for d in args.tree_dirs
-                        if os.path.commonpath([os.path.abspath(path), os.path.abspath(d)])
+                        if os.path.commonpath(
+                            [os.path.abspath(path), os.path.abspath(d)]
+                        )
                         == os.path.abspath(d)
                     ),
                     os.path.dirname(path),
                 )
-                prefix = os.path.basename(root)
+                prefix = root_prefix.get(os.path.abspath(root), os.path.basename(root))
                 rel_path = os.path.join(prefix, os.path.relpath(path, root))
             else:
-                rel_path = os.path.basename(path)
+                rel_path = os.path.relpath(path, args.data_dir)
 
             output_path = os.path.join(output_dir, rel_path + "-codex")
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
@@ -146,7 +167,9 @@ def main() -> None:
                 work_dir,
             ]
             if args.tree_dirs:
-                logging.info("TreeMode: root=%s   file=%s   work_dir=%s", root, path, work_dir)
+                logging.info(
+                    "TreeMode: root=%s   file=%s   work_dir=%s", root, path, work_dir
+                )
             else:
                 logging.info("Running codex on %s", path)
             subprocess.run(cmd, input=prompt.encode(), check=True)
@@ -159,13 +182,15 @@ def main() -> None:
     else:
         data_dir = args.data_dir
         files = [
-            os.path.join(data_dir, f)
-            for f in os.listdir(data_dir)
-            if os.path.isfile(os.path.join(data_dir, f))
+            os.path.join(dp, f)
+            for dp, _, filenames in os.walk(data_dir)
+            for f in filenames
+            if os.path.isfile(os.path.join(dp, f))
         ]
+        files = sorted(files)
     with ThreadPoolExecutor(max_workers=workers) as executor:
         list(executor.map(run_on_file, files))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- switch `output_dir` and `workers` to option flags
- preserve data-dir paths to avoid name clashes
- give every tree root a unique prefix
- skip binary files gracefully
- document updated flags and note flexible ordering

## Testing
- `python -m py_compile dispatch.py`

------
https://chatgpt.com/codex/tasks/task_e_6887f11297408324903ee1ceb0914934