### PR TITLE
Add per-file timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Simple dispatcher for running the bundled Codex binary over multiple files in pa
 ## Usage
 
 ```
-python dispatch.py TEMPLATE --data-dir DIR --output-dir OUT --workers N [-C WORK_DIR] [--codex-bin PATH]
-python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] --output-dir OUT --workers N [--recursive/--no-recursive] [-C WORK_DIR] [--codex-bin PATH]
+python dispatch.py TEMPLATE --data-dir DIR --output-dir OUT --workers N [-C WORK_DIR] [--codex-bin PATH] [--timeout SEC]
+python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] --output-dir OUT --workers N [--recursive/--no-recursive] [-C WORK_DIR] [--codex-bin PATH] [--timeout SEC]
 ```
 
 - `TEMPLATE` - path to the prompt template.
@@ -18,6 +18,9 @@ python dispatch.py TEMPLATE --tree-dirs DIR [DIR ...] --output-dir OUT --workers
 - `--recursive` / `--no-recursive` - control whether tree mode walks subdirectories (default: recursive).
 - `--codex-bin` - path to the codex binary. If not provided, the script looks for
   `codex` in `PATH` and then searches the current directory.
+- `--timeout` - per-file wall clock limit in seconds (default 900). Set to `0`
+  to disable; can also be specified via `CODEX_DISPATCH_TIMEOUT` environment
+  variable.
 
 In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results mirror the source tree: a file `src/example.txt` will produce `OUTPUT_DIR/src/example.txt-codex`. This avoids collisions when different directories contain files with the same name.
 

--- a/dispatch.py
+++ b/dispatch.py
@@ -68,6 +68,12 @@ def parse_args() -> argparse.Namespace:
         help="working directory to run Codex in (default: current directory)",
     )
     parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(os.getenv("CODEX_DISPATCH_TIMEOUT", 900)),
+        help="per-file timeout in seconds (0 = none, default 900)",
+    )
+    parser.add_argument(
         "--codex-bin",
         dest="codex_bin",
         default=None,
@@ -172,8 +178,28 @@ def main() -> None:
                 )
             else:
                 logging.info("Running codex on %s", path)
-            subprocess.run(cmd, input=prompt.encode(), check=True)
+
+            max_tries = 2
+            for attempt in range(1, max_tries + 1):
+                try:
+                    subprocess.run(
+                        cmd,
+                        input=prompt.encode(),
+                        check=True,
+                        timeout=args.timeout or None,
+                    )
+                    break
+                except subprocess.TimeoutExpired as te:
+                    if attempt == max_tries:
+                        raise
+                    logging.warning("Retrying (%s/%s) %s", attempt, max_tries, path)
+
             logging.info("Wrote %s", output_path)
+        except subprocess.TimeoutExpired as te:
+            logging.error("TIMEOUT after %ss on %s", te.timeout, path)
+        except subprocess.CalledProcessError as cpe:
+            stderr = (cpe.stderr or b"").decode(errors="ignore")
+            logging.error("Codex exit %s on %s\n%s", cpe.returncode, path, stderr)
         except Exception as exc:
             logging.error("Failed processing %s: %s", path, exc)
 


### PR DESCRIPTION
## Summary
- add --timeout flag and CODEX_DISPATCH_TIMEOUT env var
- log timeout and errors separately
- retry once on timeout
- document timeout option

## Testing
- `python -m py_compile dispatch.py`

------
https://chatgpt.com/codex/tasks/task_e_6887f6b371ac8324b18ce519b08f7695