### PR TITLE
Improve file list prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ python dispatch.py TEMPLATE --file-list LIST --output-dir OUT --workers N -C WOR
 
 In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results mirror the source tree: a file `src/example.txt` will produce `OUTPUT_DIR/src/example.txt-codex`. This avoids collisions when different directories contain files with the same name.
 
-File-list mode reads paths from a text file and processes exactly those files. Each prompt contains the filename on a separate line before its contents. The working directory provided via `-C` is used for all Codex executions, which can be helpful when a shared virtual environment or imports are needed.
+File-list mode reads paths from a text file and processes exactly those files. Each prompt contains the full resolved path on a separate line before its contents. The working directory provided via `-C` is used for all Codex executions, which can be helpful when a shared virtual environment or imports are needed.
 
 With `--output-dir` and `--workers` provided as options, arguments can be specified in any order.

--- a/dispatch.py
+++ b/dispatch.py
@@ -17,7 +17,8 @@ Supports three modes:
 ```
 
 When using ``--file-list`` the working directory supplied with ``-C`` is used
-for all Codex executions.
+for all Codex executions. Each prompt includes the full resolved path on a
+separate line before the file contents.
 """
 
 
@@ -172,7 +173,7 @@ def main() -> None:
                 logging.warning("%sSkipping non-text file %s", prefix, path)
                 return
             if args.file_list:
-                filename_line = os.path.basename(path)
+                filename_line = os.path.abspath(path)
                 prompt = f"{template}\n{filename_line}\n{data}"
             else:
                 prompt = template + "\n" + data

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -106,9 +106,49 @@ class DispatchIntegration(unittest.TestCase):
 
         out_file = os.path.join(outdir, os.path.relpath(file1) + "-codex")
         with open(out_file, "r", encoding="utf-8") as f:
-            self.assertEqual(f.read(), "TEMPLATE\ninput.txt\ncontent")
+            self.assertEqual(
+                f.read(), f"TEMPLATE\n{os.path.abspath(file1)}\ncontent"
+            )
         with open(out_file + ".workdir", "r", encoding="utf-8") as f:
             self.assertEqual(f.read(), self.workdir)
+
+    def test_file_list_resolves_path(self):
+        template = os.path.join(self.tmpdir.name, "tmpl.txt")
+        with open(template, "w", encoding="utf-8") as f:
+            f.write("TEMPLATE")
+        dir_path = os.path.join(self.tmpdir.name, "dir")
+        weird_dir = os.path.join(self.tmpdir.name, "weird")
+        os.mkdir(dir_path)
+        os.mkdir(weird_dir)
+        file1 = os.path.join(dir_path, "input.txt")
+        with open(file1, "w", encoding="utf-8") as f:
+            f.write("content")
+        weird_path = os.path.join(weird_dir, "..", "dir", "input.txt")
+        lst = os.path.join(self.tmpdir.name, "list2.txt")
+        with open(lst, "w", encoding="utf-8") as f:
+            f.write(weird_path + "\n")
+        outdir = os.path.join(self.tmpdir.name, "out2")
+        os.mkdir(outdir)
+
+        self.run_dispatch([
+            template,
+            "--file-list",
+            lst,
+            "-o",
+            outdir,
+            "-j",
+            "1",
+            "-C",
+            self.workdir,
+            "--codex-bin",
+            self.codex,
+        ])
+
+        out_file = os.path.join(outdir, os.path.relpath(weird_path) + "-codex")
+        with open(out_file, "r", encoding="utf-8") as f:
+            self.assertEqual(
+                f.read(), f"TEMPLATE\n{os.path.abspath(weird_path)}\ncontent"
+            )
 
     def test_output_collision_file_list(self):
         template = os.path.join(self.tmpdir.name, "tmpl.txt")


### PR DESCRIPTION
## Summary
- include absolute path instead of basename when building file-list prompts
- clarify README and docstring wording about prompt format
- update tests for new full-path behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881ceb900083249f0835f2f844e22c