### PR TITLE
Add generic security audit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ In flat mode, each file in `DATA_DIR` is appended to the template and sent to Co
 File-list mode reads paths from a text file and processes exactly those files. Each prompt contains the full resolved path on a separate line before its contents. The working directory provided via `-C` is used for all Codex executions, which can be helpful when a shared virtual environment or imports are needed.
 
 With `--output-dir` and `--workers` provided as options, arguments can be specified in any order.
+
+## Security audit mode
+
+Running with `--security-audit` processes files in a BFS search and expects a separate prompt describing the audit workflow. This repository ships with `prompts/security_audit_generic.txt`, a generic template that reports security findings and suggests follow-up files via absolute paths. Fork or modify this file to focus on particular bug classes (e.g. OWASP-only, memory-safety-only) or to tweak the output schema.

--- a/prompts/security_audit_generic.txt
+++ b/prompts/security_audit_generic.txt
@@ -1,0 +1,8 @@
+You are an automated code-security auditor running in a breadth-first crawl.
+You will receive one source file followed by zero or more JSON blobs from previous runs (latest last).
+Analyze the current file for exploitable or compliance-critical vulnerabilities such as memory safety, authentication bypass, injection, deserialization, or race conditions.
+Use `leads` from earlier blobs to continue investigating unfinished paths.
+If this file references other locations worth checking (imports, configs, resources), add them to "leads".
+Produce exactly one final message that ends with a single-line JSON object structured as:
+{ "findings": [ {"type": "...", "message": "...", "line": N}, ... ], "leads": [ {"path": "/abs/path", "reason": "..."}, ... ] }
+Only use absolute paths (as with os.path.abspath()). Limit to 20 findings and 20 leads, dropping the least important if needed. No additional commentary after the JSON.


### PR DESCRIPTION
## Summary
- add `prompts/security_audit_generic.txt` for BFS security auditing
- document template usage and customization in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888908098b88324819407d9650a245f