### PR TITLE
Add audit focus flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ With `--output-dir` and `--workers` provided as options, arguments can be specif
 
 ## Security audit mode
 
-Running with `--security-audit` processes files in a BFS search and expects a separate prompt describing the audit workflow. This repository ships with `prompts/security_audit_generic.txt`, a generic template that reports security findings and suggests follow-up files via absolute paths. Fork or modify this file to focus on particular bug classes (e.g. OWASP-only, memory-safety-only) or to tweak the output schema.
+Running with `--security-audit` processes files in a BFS search. The generic template at `prompts/security_audit_generic.txt` is always used as the system prompt. Provide a goal for the audit using the mandatory `--audit-focus` option. The focus text is appended after the template for each evaluation.

--- a/dispatch.py
+++ b/dispatch.py
@@ -83,10 +83,10 @@ def parse_args() -> argparse.Namespace:
         help="max BFS layers for security audit",
     )
     parser.add_argument(
-        "--template-sec",
-        dest="template_sec",
+        "--audit-focus",
+        dest="audit_focus",
         default=None,
-        help="path to security audit template",
+        help="specific focus for the security audit",
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
@@ -156,8 +156,8 @@ def parse_args() -> argparse.Namespace:
     )
     args = parser.parse_args()
     if args.security_audit:
-        if not args.template_sec:
-            parser.error("--template-sec is required with --security-audit")
+        if not args.audit_focus:
+            parser.error("--audit-focus is required with --security-audit")
         if args.depth < 1:
             parser.error("--depth must be >= 1")
         if args.passes != 1:
@@ -165,9 +165,15 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
+AUDIT_TEMPLATE_PATH = os.path.join(
+    os.path.dirname(__file__), "prompts", "security_audit_generic.txt"
+)
+
+
 def run_security_audit(args: argparse.Namespace) -> None:
-    with open(args.template_sec, "r", encoding="utf-8") as f:
-        template = f.read()
+    with open(AUDIT_TEMPLATE_PATH, "r", encoding="utf-8") as f:
+        base_template = f.read()
+    template_prefix = f"{base_template}\n{args.audit_focus}"
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
@@ -258,7 +264,7 @@ def run_security_audit(args: argparse.Namespace) -> None:
             return os.path.relpath(path), None
 
     def build_prompt(data: str, prev_blobs: list[str]) -> str:
-        parts = [template]
+        parts = [template_prefix]
         parts.extend(prev_blobs)
         parts.append(data)
         return "\n".join(parts)

--- a/tests/test_security_audit.py
+++ b/tests/test_security_audit.py
@@ -51,9 +51,6 @@ with open(out, 'w') as fh:
         subprocess.check_call([sys.executable, "dispatch.py"] + self.args, env=env)
 
     def test_bfs_dedup(self):
-        tmpl = os.path.join(self.tmpdir.name, "sec.txt")
-        with open(tmpl, "w", encoding="utf-8") as f:
-            f.write("SEC")
         tree = os.path.join(self.tmpdir.name, "tree")
         os.mkdir(tree)
         a = os.path.join(tree, "a.txt")
@@ -70,7 +67,7 @@ with open(out, 'w') as fh:
             "-j", "1",
             "--codex-bin", self.codex,
             "--security-audit",
-            "--template-sec", tmpl,
+            "--audit-focus", "TEST FOCUS",
             "--depth", "2",
         ]
         self.run_audit({"B_PATH": b})


### PR DESCRIPTION
## Summary
- include a required `--audit-focus` option in security audit mode
- always use `prompts/security_audit_generic.txt` as the system prompt
- update README and tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888938f39c083249e78ab483c856fa2