### PR TITLE
Add audit root support and flexible audit list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ python dispatch.py TEMPLATE --file-list LIST --output-dir OUT --workers N -C WOR
 - `TEMPLATE` - path to the prompt template.
 - `--data-dir` - directory containing input files (flat mode).
 - `--tree-dirs` - one or more directories to recursively walk (tree mode).
-- `--file-list` - text file containing paths to process, one per line (file-list mode).
+- `--file-list` - text file containing paths to process, one per line (file-list mode). In security audit mode entries may be either files or directories.
 - `--output-dir` - directory where results will be written.
 - `--workers` - number of parallel workers.
 - `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current directory. In file-list mode this directory is used for all files; in tree mode the default is each file's parent.
@@ -33,3 +33,5 @@ With `--output-dir` and `--workers` provided as options, arguments can be specif
 ## Security audit mode
 
 Running with `--security-audit` processes files in a BFS search. The generic template at `prompts/security_audit_generic.txt` is always used as the system prompt. Provide a goal for the audit using the mandatory `--audit-focus` option. The focus text is appended after the template for each evaluation.
+
+When used with `--file-list`, each line may reference either a file or a directory. Directories are walked according to the `--recursive` setting. The optional `--audit-root` parameter sets a base directory used to resolve relative lead paths from Codex and restricts the audit to that tree.

--- a/dispatch.py
+++ b/dispatch.py
@@ -88,6 +88,15 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="specific focus for the security audit",
     )
+    parser.add_argument(
+        "--audit-root",
+        dest="audit_root",
+        default=None,
+        help=(
+            "base directory for resolving leads and limiting the search "
+            "during security audits"
+        ),
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
         "--data-dir",
@@ -224,9 +233,25 @@ def run_security_audit(args: argparse.Namespace) -> None:
             ]
         file_list_entries = sorted(dict.fromkeys(file_list_entries))
 
+    def expand_paths(paths: list[str]) -> tuple[list[str], list[str]]:
+        out_files: list[str] = []
+        roots: list[str] = []
+        for raw in paths:
+            p = os.path.abspath(raw)
+            if os.path.isdir(p):
+                roots.append(p)
+                out_files.extend(collect_files([p], recursive=args.recursive))
+            elif os.path.isfile(p):
+                roots.append(os.path.dirname(p))
+                out_files.append(p)
+            else:
+                logging.warning("FileListMode: missing path %s", raw)
+        out_files = sorted(dict.fromkeys(out_files))
+        roots = sorted(dict.fromkeys(roots))
+        return out_files, roots
+
     if args.tree_dirs:
-        files = collect_files(args.tree_dirs, recursive=args.recursive)
-        root_dirs = [os.path.abspath(d) for d in args.tree_dirs]
+        files, root_dirs = expand_paths(args.tree_dirs)
     elif args.data_dir:
         data_dir = args.data_dir
         files = [
@@ -238,11 +263,14 @@ def run_security_audit(args: argparse.Namespace) -> None:
         files = sorted(files)
         root_dirs = [os.path.abspath(data_dir)]
     else:
-        files = [p for p in file_list_entries if os.path.exists(p)]
-        missing = [p for p in file_list_entries if not os.path.exists(p)]
-        for m in missing:
-            logging.warning("FileListMode: missing path %s", m)
-        root_dirs = list({os.path.dirname(os.path.abspath(p)) for p in files})
+        files, root_dirs = expand_paths(file_list_entries)
+
+    if args.audit_root:
+        audit_root = os.path.abspath(args.audit_root)
+        if not os.path.isdir(audit_root):
+            logging.error("--audit-root %s does not exist", audit_root)
+            sys.exit(1)
+        root_dirs = [audit_root]
 
     def rel_and_root(path: str) -> tuple[str, str | None]:
         if args.tree_dirs:
@@ -350,11 +378,24 @@ def run_security_audit(args: argparse.Namespace) -> None:
                 for lead in parsed.get("leads", []):
                     lp = lead.get("path")
                     if lp:
-                        abs_lp = os.path.abspath(lp)
-                        if os.path.exists(abs_lp) and any(
-                            os.path.commonpath([abs_lp, rd]) == rd for rd in root_dirs
+                        if args.audit_root:
+                            cand = (
+                                os.path.join(args.audit_root, lp)
+                                if not os.path.isabs(lp)
+                                else lp
+                            )
+                            cand = os.path.abspath(cand)
+                            if not os.path.exists(cand):
+                                alt = os.path.abspath(os.path.join(args.audit_root, lp.lstrip(os.sep)))
+                                cand = alt if os.path.exists(alt) else None
+                        else:
+                            cand = os.path.abspath(lp)
+                            if not os.path.exists(cand):
+                                cand = None
+                        if cand and any(
+                            os.path.commonpath([cand, rd]) == rd for rd in root_dirs
                         ):
-                            leads.append(abs_lp)
+                            leads.append(cand)
                     else:
                         leads.append(None)
                 return p, leads

--- a/tests/test_security_audit.py
+++ b/tests/test_security_audit.py
@@ -82,5 +82,44 @@ with open(out, 'w') as fh:
         self.assertEqual(set(summary.keys()), {os.path.abspath(a), os.path.abspath(b)})
         self.assertEqual(summary[os.path.abspath(b)]["depth"], 0)
 
+    def test_audit_root_resolves_relative(self):
+        tree = os.path.join(self.tmpdir.name, "tree2")
+        os.makedirs(os.path.join(tree, "sub"))
+        a = os.path.join(tree, "a.txt")
+        b = os.path.join(tree, "sub", "b.txt")
+        for p in (a, b):
+            with open(p, "w", encoding="utf-8") as f:
+                f.write(p)
+        lst = os.path.join(self.tmpdir.name, "list.txt")
+        with open(lst, "w", encoding="utf-8") as f:
+            f.write(a + "\n")
+        outdir = os.path.join(self.tmpdir.name, "out2")
+        os.mkdir(outdir)
+        self.args = [
+            "dummy",
+            "--file-list",
+            lst,
+            "-o",
+            outdir,
+            "-j",
+            "1",
+            "--codex-bin",
+            self.codex,
+            "--security-audit",
+            "--audit-focus",
+            "TEST",
+            "--depth",
+            "2",
+            "--audit-root",
+            tree,
+            "-C",
+            tree,
+        ]
+        self.run_audit({"B_PATH": "sub/b.txt"})
+        with open(os.path.join(outdir, "security_summary.json"), "r", encoding="utf-8") as f:
+            summary = json.load(f)
+        self.assertIn(os.path.abspath(b), summary)
+        self.assertEqual(summary[os.path.abspath(b)]["depth"], 1)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support `--audit-root` for resolving Codex leads within a directory
- allow directories in file lists for audit mode
- resolve relative lead paths against the audit root
- document new behaviour and add tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688894e8f590832484e7a2051f2554f8