### PR TITLE
Add mock audit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ With `--output-dir` and `--workers` provided as options, arguments can be specif
 Running with `--security-audit` processes files in a BFS search. The generic template at `prompts/security_audit_generic.txt` is always used as the system prompt. Provide a goal for the audit using the mandatory `--audit-focus` option. The focus text is appended after the template for each evaluation.
 
 When used with `--file-list`, each line may reference either a file or a directory. Directories are walked according to the `--recursive` setting. The optional `--audit-root` parameter sets a base directory used to resolve relative lead paths from Codex and restricts the audit to that tree.
+
+For testing workflows without invoking Codex, combine `--security-audit` with
+`--mock-audit`. This stub mode generates deterministic JSON results and random
+follow-up paths within the audited tree, writing outputs to the requested
+directory just like a real run.

--- a/dispatch.py
+++ b/dispatch.py
@@ -9,6 +9,7 @@ import uuid
 import json
 from collections import defaultdict
 import re
+import random
 
 
 """Dispatch tool for running the Codex binary over many files in parallel.
@@ -98,6 +99,12 @@ def parse_args() -> argparse.Namespace:
             "during security audits"
         ),
     )
+    parser.add_argument(
+        "--mock-audit",
+        action="store_true",
+        default=False,
+        help="generate fake audit responses instead of invoking Codex",
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
         "--data-dir",
@@ -165,6 +172,8 @@ def parse_args() -> argparse.Namespace:
         help="mapping filename for multi-pass mode",
     )
     args = parser.parse_args()
+    if args.mock_audit and not args.security_audit:
+        parser.error("--mock-audit requires --security-audit")
     if args.security_audit:
         if not args.audit_focus:
             parser.error("--audit-focus is required with --security-audit")
@@ -187,30 +196,33 @@ def run_security_audit(args: argparse.Namespace) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     codex_bin = args.codex_bin
-    if codex_bin:
-        codex_bin = os.path.abspath(codex_bin)
-        if not os.path.exists(codex_bin):
-            logging.error("Codex binary not found at %s", codex_bin)
-            sys.exit(1)
+    if not args.mock_audit:
+        if codex_bin:
+            codex_bin = os.path.abspath(codex_bin)
+            if not os.path.exists(codex_bin):
+                logging.error("Codex binary not found at %s", codex_bin)
+                sys.exit(1)
+        else:
+            codex_bin = shutil.which("codex")
+            if codex_bin is None:
+                candidates = [
+                    f
+                    for f in os.listdir(os.getcwd())
+                    if os.path.isfile(f) and "codex" in f and os.access(f, os.X_OK)
+                ]
+                if len(candidates) == 1:
+                    codex_bin = os.path.abspath(candidates[0])
+                elif len(candidates) > 1:
+                    logging.error(
+                        "Multiple codex binaries found in current directory: %s",
+                        ", ".join(candidates),
+                    )
+                    sys.exit(1)
+                else:
+                    logging.error("Codex binary not found in PATH or current directory")
+                    sys.exit(1)
     else:
-        codex_bin = shutil.which("codex")
-        if codex_bin is None:
-            candidates = [
-                f
-                for f in os.listdir(os.getcwd())
-                if os.path.isfile(f) and "codex" in f and os.access(f, os.X_OK)
-            ]
-            if len(candidates) == 1:
-                codex_bin = os.path.abspath(candidates[0])
-            elif len(candidates) > 1:
-                logging.error(
-                    "Multiple codex binaries found in current directory: %s",
-                    ", ".join(candidates),
-                )
-                sys.exit(1)
-            else:
-                logging.error("Codex binary not found in PATH or current directory")
-                sys.exit(1)
+        codex_bin = codex_bin or "codex"
 
     os.makedirs(args.output_dir, exist_ok=True)
 
@@ -271,6 +283,13 @@ def run_security_audit(args: argparse.Namespace) -> None:
             logging.error("--audit-root %s does not exist", audit_root)
             sys.exit(1)
         root_dirs = [audit_root]
+
+    all_files: list[str] = []
+    if args.mock_audit:
+        for rd in root_dirs:
+            all_files.extend(collect_files([rd], recursive=True))
+        all_files = sorted(dict.fromkeys(all_files))
+        random.seed(0)
 
     def rel_and_root(path: str) -> tuple[str, str | None]:
         if args.tree_dirs:
@@ -362,26 +381,40 @@ def run_security_audit(args: argparse.Namespace) -> None:
 
                 os.makedirs(os.path.dirname(out_base), exist_ok=True)
 
-                cmd = [
-                    codex_bin,
-                    "exec",
-                    "--output-last-message",
-                    out_base,
-                    "--dangerously-bypass-approvals-and-sandbox",
-                    "--skip-git-repo-check",
-                    "-C",
-                    work_dir,
-                ]
+                if args.mock_audit:
+                    notes = [f"mock note for {os.path.basename(token)}"]
+                    follow = []
+                    if all_files:
+                        fp = random.choice(all_files)
+                        root_dir = next(
+                            (rd for rd in root_dirs if os.path.commonpath([fp, rd]) == rd),
+                            root_dirs[0] if root_dirs else os.path.dirname(fp),
+                        )
+                        follow.append(os.path.relpath(fp, root_dir))
+                    mock_res = {"notes": notes, "followup": follow}
+                    with open(out_base, "w", encoding="utf-8") as mf:
+                        mf.write("MOCK\n" + json.dumps(mock_res))
+                else:
+                    cmd = [
+                        codex_bin,
+                        "exec",
+                        "--output-last-message",
+                        out_base,
+                        "--dangerously-bypass-approvals-and-sandbox",
+                        "--skip-git-repo-check",
+                        "-C",
+                        work_dir,
+                    ]
 
-                try:
-                    _invoke_codex(cmd, prompt, args.timeout, key)
-                except subprocess.TimeoutExpired as te:
-                    logging.error("TIMEOUT after %ss on %s", te.timeout, key)
-                except subprocess.CalledProcessError as cpe:
-                    stderr = (cpe.stderr or b"").decode(errors="ignore")
-                    logging.error("Codex exit %s on %s\n%s", cpe.returncode, key, stderr)
-                except Exception as exc:
-                    logging.error("Failed processing %s: %s", key, exc)
+                    try:
+                        _invoke_codex(cmd, prompt, args.timeout, key)
+                    except subprocess.TimeoutExpired as te:
+                        logging.error("TIMEOUT after %ss on %s", te.timeout, key)
+                    except subprocess.CalledProcessError as cpe:
+                        stderr = (cpe.stderr or b"").decode(errors="ignore")
+                        logging.error("Codex exit %s on %s\n%s", cpe.returncode, key, stderr)
+                    except Exception as exc:
+                        logging.error("Failed processing %s: %s", key, exc)
 
                 try:
                     with open(out_base, "r", encoding="utf-8") as of:

--- a/tests/test_security_audit.py
+++ b/tests/test_security_audit.py
@@ -121,5 +121,49 @@ with open(out, 'w') as fh:
         self.assertIn(os.path.abspath(b), summary)
         self.assertEqual(summary[os.path.abspath(b)]["depth"], 1)
 
+
+class TestMockAudit(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def run_audit(self):
+        subprocess.check_call([sys.executable, "dispatch.py"] + self.args)
+
+    def test_mock_mode_generates_outputs(self):
+        root = os.path.join(self.tmpdir.name, "proj")
+        os.mkdir(root)
+        for idx in range(3):
+            with open(os.path.join(root, f"f{idx}.txt"), "w", encoding="utf-8") as f:
+                f.write("x")
+        outdir = os.path.join(self.tmpdir.name, "out")
+        os.mkdir(outdir)
+        self.args = [
+            "dummy",
+            "--tree-dirs",
+            root,
+            "-o",
+            outdir,
+            "-j",
+            "1",
+            "--security-audit",
+            "--audit-focus",
+            "TEST",
+            "--depth",
+            "2",
+            "--mock-audit",
+        ]
+        self.run_audit()
+        depth0 = os.path.join(outdir, "security", "depth_0")
+        found = False
+        for rootdir, _, files in os.walk(depth0):
+            if any(f.endswith("-audit.json") for f in files):
+                found = True
+                break
+        self.assertTrue(found)
+        with open(os.path.join(outdir, "security_summary.json"), "r", encoding="utf-8") as f:
+            summary = json.load(f)
+        self.assertTrue(len(summary) >= 3)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `--mock-audit` option for BFS security audits
- simulate Codex responses with deterministic random followups
- document stub mode in README
- test stub audit mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889c2f417c8324878b66690b6fcbdc