### PR TITLE
Capture stderr in codex invocations

### DIFF
--- a/codexdispatch/utils.py
+++ b/codexdispatch/utils.py
@@ -30,6 +30,7 @@ def _invoke_codex(cmd: list[str], prompt: str, timeout: int | None, path: str) -
                 input=prompt.encode(),
                 check=True,
                 timeout=timeout or None,
+                stderr=subprocess.PIPE,
             )
             break
         except subprocess.TimeoutExpired:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import subprocess
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from codexdispatch.utils import _invoke_codex
+
+
+class TestInvokeCodex(unittest.TestCase):
+    def test_stderr_captured_on_failure(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        script = os.path.join(tmpdir.name, "fail.py")
+        with open(script, "w", encoding="utf-8") as f:
+            f.write(
+                "#!/usr/bin/env python3\n"
+                "import sys\n"
+                "sys.stderr.write('oops\\n')\n"
+                "sys.exit(1)\n"
+            )
+        os.chmod(script, 0o755)
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            _invoke_codex([script], "", None, script)
+        self.assertEqual(cm.exception.stderr, b"oops\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- capture stderr when launching `codex`
- test `_invoke_codex` failure stderr

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a346b968832496fd155cc69626c1