### PR TITLE
Configure flake8 and resolve lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -5,10 +5,11 @@ import tempfile
 import json
 
 import unittest
-from unittest import mock
+import unittest.mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import dispatch
+import dispatch  # noqa: E402
+
 
 class TestParseArgs(unittest.TestCase):
     def test_parse_data_dir(self):
@@ -249,6 +250,7 @@ class DispatchIntegration(unittest.TestCase):
         self.assertEqual(len(mapping), 1)
         self.assertEqual(mapping[0]["input"], os.path.abspath(f1))
         self.assertEqual(mapping[0]["output"], os.path.abspath(out1))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_security_audit.py
+++ b/tests/test_security_audit.py
@@ -6,7 +6,8 @@ import json
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import dispatch
+import dispatch  # noqa: E402
+
 
 class TestParseCodexJson(unittest.TestCase):
     def test_parse_good(self):
@@ -18,6 +19,7 @@ class TestParseCodexJson(unittest.TestCase):
     def test_parse_bad(self):
         res = dispatch.parse_codex_json("not-json")
         self.assertEqual(res, {"notes": [], "followup": []})
+
 
 class TestAuditBfs(unittest.TestCase):
     def setUp(self):
@@ -71,8 +73,18 @@ with open(out, 'w') as fh:
             "--depth", "2",
         ]
         self.run_audit({"B_PATH": b})
-        d0_a = os.path.join(outdir, "security", "depth_0", os.path.join("1_" + os.path.basename(tree), "a.txt") + "-audit.json")
-        d0_b = os.path.join(outdir, "security", "depth_0", os.path.join("1_" + os.path.basename(tree), "b.txt") + "-audit.json")
+        d0_a = os.path.join(
+            outdir,
+            "security",
+            "depth_0",
+            os.path.join("1_" + os.path.basename(tree), "a.txt") + "-audit.json",
+        )
+        d0_b = os.path.join(
+            outdir,
+            "security",
+            "depth_0",
+            os.path.join("1_" + os.path.basename(tree), "b.txt") + "-audit.json",
+        )
         self.assertTrue(os.path.exists(d0_a))
         self.assertTrue(os.path.exists(d0_b))
         d1 = os.path.join(outdir, "security", "depth_1")
@@ -164,6 +176,7 @@ class TestMockAudit(unittest.TestCase):
         with open(os.path.join(outdir, "security_summary.json"), "r", encoding="utf-8") as f:
             summary = json.load(f)
         self.assertTrue(len(summary) >= 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- set project-wide max line length for flake8
- fix lint in test suites and keep dispatch import
- wrap long paths in `tests/test_security_audit.py`

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a348cdf08324873f65854c203b63