### PR TITLE
Fix test import paths

### DIFF
--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -7,8 +7,7 @@ import json
 import unittest
 import unittest.mock
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import dispatch  # noqa: E402
+import codexdispatch as dispatch
 
 
 class TestParseArgs(unittest.TestCase):

--- a/tests/test_security_audit.py
+++ b/tests/test_security_audit.py
@@ -5,8 +5,7 @@ import tempfile
 import json
 import unittest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-import dispatch  # noqa: E402
+import codexdispatch as dispatch
 
 
 class TestParseCodexJson(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,8 @@
 import os
-import sys
 import subprocess
 import tempfile
 import unittest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from codexdispatch.utils import _invoke_codex
 
 


### PR DESCRIPTION
## Summary
- import codexdispatch directly in tests
- remove unused imports

## Testing
- `flake8`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ac91b35c8324b65f5a9d4588060b