### PR TITLE
Refactor file discovery

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List
 
 from .args import parse_args
-from .utils import collect_files, _invoke_codex, find_codex_bin
+from .utils import collect_files, _invoke_codex, find_codex_bin, load_files
 from .security_audit import run_security_audit
 
 
@@ -149,14 +149,7 @@ def main() -> None:
     if args.tree_dirs:
         files = collect_files(args.tree_dirs, recursive=args.recursive)
     elif args.data_dir:
-        data_dir = args.data_dir
-        files = [
-            os.path.join(dp, f)
-            for dp, _, filenames in os.walk(data_dir)
-            for f in filenames
-            if os.path.isfile(os.path.join(dp, f))
-        ]
-        files = sorted(files)
+        files = load_files(args.data_dir)
     else:
         files = [p for p in file_list_entries if os.path.exists(p)]
         missing = [p for p in file_list_entries if not os.path.exists(p)]

--- a/codexdispatch/security_audit.py
+++ b/codexdispatch/security_audit.py
@@ -10,7 +10,13 @@ from heapq import heappush, heappop
 from pathlib import Path
 import re
 
-from .utils import collect_files, parse_codex_json, _invoke_codex, find_codex_bin
+from .utils import (
+    collect_files,
+    parse_codex_json,
+    _invoke_codex,
+    find_codex_bin,
+    load_files,
+)
 
 AUDIT_TEMPLATE_PATH = os.path.join(
     os.path.dirname(__file__), "..", "prompts", "security_audit_generic.txt"
@@ -69,15 +75,8 @@ def run_security_audit(args) -> None:
     if args.tree_dirs:
         files, root_dirs = expand_paths(args.tree_dirs)
     elif args.data_dir:
-        data_dir = args.data_dir
-        files = [
-            os.path.join(dp, f)
-            for dp, _, filenames in os.walk(data_dir)
-            for f in filenames
-            if os.path.isfile(os.path.join(dp, f))
-        ]
-        files = sorted(files)
-        root_dirs = [os.path.abspath(data_dir)]
+        files = load_files(args.data_dir)
+        root_dirs = [os.path.abspath(args.data_dir)]
     else:
         files, root_dirs = expand_paths(file_list_entries)
 

--- a/codexdispatch/utils.py
+++ b/codexdispatch/utils.py
@@ -6,6 +6,22 @@ import json
 import shutil
 
 
+def load_files(data_dir: str) -> list[str]:
+    """Return a sorted list of file paths under *data_dir*.
+
+    The directory is walked recursively and only regular files are returned.
+    """
+
+    return sorted(
+        [
+            os.path.join(dp, f)
+            for dp, _, filenames in os.walk(data_dir)
+            for f in filenames
+            if os.path.isfile(os.path.join(dp, f))
+        ]
+    )
+
+
 def collect_files(dirs: list[str], recursive: bool = True) -> list[str]:
     files: list[str] = []
     for root in dirs:


### PR DESCRIPTION
## Summary
- add `load_files` helper for recursively listing files
- use `load_files` in dispatcher and security_audit to avoid duplicate logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ac941d048324ab377c1a8229c330