### PR TITLE
Add flag to skip path line in file-list mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python dispatch.py TEMPLATE --file-list LIST --output-dir OUT --workers N -C WOR
 
 In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results mirror the source tree: a file `src/example.txt` will produce `OUTPUT_DIR/src/example.txt-codex`. This avoids collisions when different directories contain files with the same name.
 
-File-list mode reads paths from a text file and processes exactly those files. Each prompt contains the full resolved path on a separate line before its contents. The working directory provided via `-C` is used for all Codex executions, which can be helpful when a shared virtual environment or imports are needed.
+File-list mode reads paths from a text file and processes exactly those files. By default each prompt contains the full resolved path on a separate line before its contents. Provide `--no-prepend-path` to omit this line. The working directory provided via `-C` is used for all Codex executions, which can be helpful when a shared virtual environment or imports are needed.
 
 With `--output-dir` and `--workers` provided as options, arguments can be specified in any order.
 

--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -76,6 +76,13 @@ def parse_args() -> argparse.Namespace:
         help="text file containing absolute/relative paths, one per line",
     )
     parser.add_argument(
+        "--prepend-path",
+        dest="prepend_path",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="prepend full resolved path before file contents in file-list mode",
+    )
+    parser.add_argument(
         "-o",
         "--output-dir",
         required=True,

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -97,11 +97,10 @@ def main() -> None:
                 logging.warning("%sSkipping non-text file %s", prefix, path)
                 return
             prev_output = prev_outputs.get(path)
-            if args.file_list:
+            file_data = data
+            if args.file_list and args.prepend_path:
                 filename_line = os.path.abspath(path)
-                file_data = f"{filename_line}\n{data}"
-            else:
-                file_data = data
+                file_data = f"{filename_line}\n{file_data}"
             prompt = build_prompt(file_data, prev_output)
 
             rel_path, root = rel_and_root(path)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -73,6 +73,23 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(args.file_list, "list.txt")
         self.assertIsNone(args.data_dir)
         self.assertIsNone(args.tree_dirs)
+        self.assertTrue(args.prepend_path)
+
+    def test_parse_no_prepend_path(self):
+        argv = [
+            "dispatch.py",
+            "tmpl",
+            "--file-list",
+            "list.txt",
+            "-o",
+            "out",
+            "-j",
+            "1",
+            "--no-prepend-path",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = dispatch.parse_args()
+        self.assertFalse(args.prepend_path)
 
 
 class DispatchIntegration(unittest.TestCase):
@@ -169,6 +186,38 @@ class DispatchIntegration(unittest.TestCase):
             self.assertEqual(
                 f.read(), f"TEMPLATE\n{os.path.abspath(weird_path)}\ncontent"
             )
+
+    def test_file_list_without_prepend_path(self):
+        template = os.path.join(self.tmpdir.name, "tmpl.txt")
+        with open(template, "w", encoding="utf-8") as f:
+            f.write("TEMPLATE")
+        file1 = os.path.join(self.tmpdir.name, "input.txt")
+        with open(file1, "w", encoding="utf-8") as f:
+            f.write("content")
+        lst = os.path.join(self.tmpdir.name, "list.txt")
+        with open(lst, "w", encoding="utf-8") as f:
+            f.write(file1 + "\n")
+        outdir = os.path.join(self.tmpdir.name, "out")
+        os.mkdir(outdir)
+
+        self.run_dispatch([
+            template,
+            "--file-list",
+            lst,
+            "-o",
+            outdir,
+            "-j",
+            "1",
+            "-C",
+            self.workdir,
+            "--codex-bin",
+            self.codex,
+            "--no-prepend-path",
+        ])
+
+        out_file = os.path.join(outdir, os.path.relpath(file1) + "-codex")
+        with open(out_file, "r", encoding="utf-8") as f:
+            self.assertEqual(f.read(), "TEMPLATE\ncontent")
 
     def test_output_collision_file_list(self):
         template = os.path.join(self.tmpdir.name, "tmpl.txt")


### PR DESCRIPTION
## Summary
- add `--no-prepend-path` flag to omit absolute path line in file-list prompts
- document `--no-prepend-path` in README
- test parsing and behavior of optional path line

## Testing
- `PYTHONPATH=. pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_688e7b32a6c08324b6b85802a025953a