### PR TITLE
Add GitLab findings mode

### DIFF
--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -75,6 +75,11 @@ def parse_args() -> argparse.Namespace:
         dest="file_list",
         help="text file containing absolute/relative paths, one per line",
     )
+    group.add_argument(
+        "--findings-json",
+        dest="findings_json",
+        help="GitLab findings.json input file",
+    )
     parser.add_argument(
         "--prepend-path",
         dest="prepend_path",
@@ -104,7 +109,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "-C",
         "--work-dir",
-        default=os.getcwd(),
+        dest="work_dir",
+        default=None,
         help="working directory to run Codex in (default: current directory)",
     )
     parser.add_argument(
@@ -131,6 +137,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="mapping filename for multi-pass mode",
     )
+    parser.add_argument(
+        "--relative-dir",
+        dest="relative_dir",
+        default=None,
+        help="base directory to resolve findings file paths",
+    )
     args = parser.parse_args()
     if args.mock_audit and not args.security_audit:
         parser.error("--mock-audit requires --security-audit")
@@ -141,4 +153,8 @@ def parse_args() -> argparse.Namespace:
             parser.error("--depth must be >= 1")
         if args.passes != 1:
             parser.error("--passes is not supported with --security-audit")
+    if args.findings_json and not args.work_dir:
+        parser.error("--work-dir is required with --findings-json")
+    if args.work_dir is None:
+        args.work_dir = os.getcwd()
     return args

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 import subprocess
 import json
+import re
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List
 
@@ -14,11 +15,90 @@ from .utils import collect_files, _invoke_codex, find_codex_bin, load_files
 from .security_audit import run_security_audit
 
 
+def _run_findings_mode(args) -> None:
+    with open(args.template, "r", encoding="utf-8") as f:
+        template = f.read()
+    with open(args.findings_json, "r", encoding="utf-8") as jf:
+        findings = json.load(jf)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    codex_bin = find_codex_bin(args.codex_bin)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    entries: list[tuple[str, dict, str]] = []
+    all_paths: list[str] = []
+    for key, data in findings.items():
+        finding = data.get("finding", {})
+        for path in data.get("files", []):
+            entries.append((key, finding, path))
+            all_paths.append(path)
+
+    base: str | None = None
+    if args.relative_dir and all_paths:
+        if len(all_paths) == 1:
+            base = os.path.dirname(all_paths[0])
+        else:
+            base = os.path.commonpath(all_paths)
+
+    def worker(item: tuple[str, dict, str]) -> None:
+        key, finding, orig_path = item
+        path = orig_path
+        if args.relative_dir and base:
+            rel = os.path.relpath(orig_path, base)
+            path = os.path.join(args.relative_dir, rel)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                src = f.read()
+        except UnicodeDecodeError:
+            logging.warning("Skipping non-text file %s", path)
+            return
+        except OSError as exc:
+            logging.error("Failed reading %s: %s", path, exc)
+            return
+        finding_json = json.dumps(finding, indent=2)
+        prompt = f"{template}\n{key}\n{finding_json}\n{src}"
+        slug = re.sub(r"[^A-Za-z0-9._-]+", "_", key)[:50]
+        rel_out = (
+            os.path.relpath(path, args.relative_dir)
+            if args.relative_dir
+            else os.path.relpath(path)
+        )
+        out_path = os.path.join(args.output_dir, slug, f"{rel_out}-codex")
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        cmd = [
+            codex_bin,
+            "exec",
+            "--output-last-message",
+            out_path,
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            "-C",
+            args.work_dir,
+        ]
+        logging.info("FindingsMode: %s -> %s", path, out_path)
+        try:
+            _invoke_codex(cmd, prompt, args.timeout, path)
+        except subprocess.TimeoutExpired as te:
+            logging.error("TIMEOUT after %ss on %s", te.timeout, path)
+        except subprocess.CalledProcessError as cpe:
+            stderr = (cpe.stderr or b"").decode(errors="ignore")
+            logging.error("Codex exit %s on %s\n%s", cpe.returncode, path, stderr)
+        except Exception as exc:
+            logging.error("Failed processing %s: %s", path, exc)
+
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        list(ex.map(worker, entries))
+
+
 def main() -> None:
     args = parse_args()
 
     if args.security_audit:
         run_security_audit(args)
+        return
+    if getattr(args, "findings_json", None):
+        _run_findings_mode(args)
         return
 
     template_path = args.template

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 import tempfile
 import json
+import re
 
 import unittest
 import unittest.mock
@@ -90,6 +91,38 @@ class TestParseArgs(unittest.TestCase):
         with unittest.mock.patch.object(sys, "argv", argv):
             args = dispatch.parse_args()
         self.assertFalse(args.prepend_path)
+
+    def test_parse_findings_json(self):
+        argv = [
+            "dispatch.py",
+            "tmpl",
+            "--findings-json",
+            "find.json",
+            "-o",
+            "out",
+            "-j",
+            "1",
+            "-C",
+            "wd",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = dispatch.parse_args()
+        self.assertEqual(args.findings_json, "find.json")
+
+    def test_findings_requires_workdir(self):
+        argv = [
+            "dispatch.py",
+            "tmpl",
+            "--findings-json",
+            "find.json",
+            "-o",
+            "out",
+            "-j",
+            "1",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit):
+                dispatch.parse_args()
 
 
 class DispatchIntegration(unittest.TestCase):
@@ -254,6 +287,47 @@ class DispatchIntegration(unittest.TestCase):
         out_b = os.path.join(outdir, os.path.relpath(fb) + "-codex")
         self.assertTrue(os.path.exists(out_a))
         self.assertTrue(os.path.exists(out_b))
+
+    def test_gitlab_findings_mode(self):
+        template = os.path.join(self.tmpdir.name, "tmpl.txt")
+        with open(template, "w", encoding="utf-8") as f:
+            f.write("TEMPLATE")
+        src_file = os.path.join(self.tmpdir.name, "src.txt")
+        with open(src_file, "w", encoding="utf-8") as f:
+            f.write("SRC")
+        findings = {
+            "Some::Key": {"finding": {"method": "m"}, "files": ["/orig/src.txt"]}
+        }
+        findings_path = os.path.join(self.tmpdir.name, "findings.json")
+        with open(findings_path, "w", encoding="utf-8") as jf:
+            json.dump(findings, jf)
+        outdir = os.path.join(self.tmpdir.name, "out")
+        os.mkdir(outdir)
+
+        self.run_dispatch([
+            template,
+            "--findings-json",
+            findings_path,
+            "--relative-dir",
+            self.tmpdir.name,
+            "-o",
+            outdir,
+            "-j",
+            "1",
+            "-C",
+            self.workdir,
+            "--codex-bin",
+            self.codex,
+        ])
+
+        slug = re.sub(r"[^A-Za-z0-9._-]+", "_", "Some::Key")[:50]
+        out_file = os.path.join(outdir, slug, "src.txt-codex")
+        with open(out_file, "r", encoding="utf-8") as f:
+            self.assertEqual(
+                f.read(), "TEMPLATE\nSome::Key\n{\n  \"method\": \"m\"\n}\nSRC"
+            )
+        with open(out_file + ".workdir", "r", encoding="utf-8") as f:
+            self.assertEqual(f.read(), self.workdir)
 
     def test_multi_pass_tree_dirs(self):
         template = os.path.join(self.tmpdir.name, "tmpl.txt")


### PR DESCRIPTION
## Summary
- support `--findings-json` and `--relative-dir` options requiring `-C/--work-dir`
- add dispatcher mode to parse GitLab findings and run Codex against each file
- cover new mode with unit and integration tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ea883c4988324a021c095a5dcfb8a