### PR TITLE
Use typing.Optional for union types to support Python 3.9

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -8,7 +8,7 @@ import subprocess
 import json
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .args import parse_args
 from .utils import collect_files, _invoke_codex, find_codex_bin, load_files
@@ -34,7 +34,7 @@ def _run_findings_mode(args) -> None:
             entries.append((key, finding, path))
             all_paths.append(path)
 
-    base: str | None = None
+    base: Optional[str] = None
     if args.relative_dir and all_paths:
         if len(all_paths) == 1:
             base = os.path.dirname(all_paths[0])
@@ -162,7 +162,7 @@ def main() -> None:
         else:
             return os.path.relpath(path), None
 
-    def build_prompt(data: str, prev_output: str | None) -> str:
+    def build_prompt(data: str, prev_output: Optional[str]) -> str:
         if prev_output is None:
             return f"{template}\n{data}"
         return f"{template}\n{prev_output}\n{data}"

--- a/codexdispatch/security_audit.py
+++ b/codexdispatch/security_audit.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from collections import defaultdict
 from heapq import heappush, heappop
 from pathlib import Path
+from typing import Optional
 import re
 
 from .utils import (
@@ -134,7 +135,7 @@ def run_security_audit(args) -> None:
                 priority += weight
         return priority
 
-    def rel_and_root(path: str) -> tuple[str, str | None]:
+    def rel_and_root(path: str) -> tuple[str, Optional[str]]:
         if args.tree_dirs:
             root = next(
                 (
@@ -162,7 +163,7 @@ def run_security_audit(args) -> None:
         parts.append(data)
         return "\n".join(parts)
 
-    def resolve_path(lead: str) -> str | None:
+    def resolve_path(lead: str) -> Optional[str]:
         if args.audit_root:
             base = os.path.abspath(args.audit_root)
             cand = os.path.join(base, lead) if not os.path.isabs(lead) else lead

--- a/codexdispatch/utils.py
+++ b/codexdispatch/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import logging
 import json
 import shutil
+from typing import Optional
 
 
 def load_files(data_dir: str) -> list[str]:
@@ -39,7 +40,7 @@ def collect_files(dirs: list[str], recursive: bool = True) -> list[str]:
     return sorted(files)
 
 
-def find_codex_bin(path_hint: str | None) -> str:
+def find_codex_bin(path_hint: Optional[str]) -> str:
     """Return the path to the codex binary.
 
     If *path_hint* is provided it must exist, otherwise the function searches
@@ -77,7 +78,9 @@ def find_codex_bin(path_hint: str | None) -> str:
     sys.exit(1)
 
 
-def _invoke_codex(cmd: list[str], prompt: str, timeout: int | None, path: str) -> None:
+def _invoke_codex(
+    cmd: list[str], prompt: str, timeout: Optional[int], path: str
+) -> None:
     max_tries = 2
     for attempt in range(1, max_tries + 1):
         try:


### PR DESCRIPTION
## Summary
- replace PEP 604 union syntax with `typing.Optional` to avoid runtime errors on Python <3.10
- update dispatcher, utilities, and security audit modules accordingly

## Testing
- `python3 dispatch.py --help`
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eaa56ab208324ab1bef5d31883b37