### PR TITLE
Include file path in findings prompts

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -57,7 +57,8 @@ def _run_findings_mode(args) -> None:
             logging.error("Failed reading %s: %s", path, exc)
             return
         finding_json = json.dumps(finding, indent=2)
-        prompt = f"{template}\n{key}\n{finding_json}\n{src}"
+        full_path = os.path.abspath(path)
+        prompt = f"{template}\n{finding_json}\n{full_path}\n{src}"
         slug = re.sub(r"[^A-Za-z0-9._-]+", "_", key)[:50]
         rel_out = (
             os.path.relpath(path, args.relative_dir)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -324,7 +324,8 @@ class DispatchIntegration(unittest.TestCase):
         out_file = os.path.join(outdir, slug, "src.txt-codex")
         with open(out_file, "r", encoding="utf-8") as f:
             self.assertEqual(
-                f.read(), "TEMPLATE\nSome::Key\n{\n  \"method\": \"m\"\n}\nSRC"
+                f.read(),
+                f"TEMPLATE\n{{\n  \"method\": \"m\"\n}}\n{os.path.abspath(src_file)}\nSRC",
             )
         with open(out_file + ".workdir", "r", encoding="utf-8") as f:
             self.assertEqual(f.read(), self.workdir)


### PR DESCRIPTION
## Summary
- Add full resolved file path to prompts when running in `--findings-json` mode
- Update GitLab findings integration test to expect file path in Codex input

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb0049e2c832487971f55c54ac5d0