### PR TITLE
Add paramtrace scanning mode

### DIFF
--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -6,7 +6,7 @@ import os
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("template", help="path to prompt template")
+    parser.add_argument("template", nargs="?", help="path to prompt template")
     parser.add_argument(
         "--security-audit",
         action="store_true",
@@ -58,7 +58,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="path to JSON with custom scoring rules",
     )
-    group = parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--data-dir",
         dest="data_dir",
@@ -90,14 +90,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "-o",
         "--output-dir",
-        required=True,
+        required=False,
         help="directory for codex outputs",
     )
     parser.add_argument(
         "-j",
         "--workers",
         type=int,
-        required=True,
+        required=False,
         help="number of parallel workers",
     )
     parser.add_argument(
@@ -143,7 +143,23 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="base directory to resolve findings file paths",
     )
+    parser.add_argument(
+        "--scan-paramtrace",
+        dest="scan_paramtrace",
+        default=None,
+        help="recursively scan directory for paramtrace outputs",
+    )
     args = parser.parse_args()
+    if args.scan_paramtrace:
+        return args
+    if args.template is None:
+        parser.error("template is required")
+    if not any([args.data_dir, args.tree_dirs, args.file_list, args.findings_json]):
+        parser.error(
+            "one of --data-dir, --tree-dirs, --file-list, or --findings-json is required"
+        )
+    if args.output_dir is None or args.workers is None:
+        parser.error("--output-dir and --workers are required")
     if args.mock_audit and not args.security_audit:
         parser.error("--mock-audit requires --security-audit")
     if args.security_audit:

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -15,6 +15,39 @@ from .utils import collect_files, _invoke_codex, find_codex_bin, load_files
 from .security_audit import run_security_audit
 
 
+def _run_paramtrace_scan(path: str) -> None:
+    matches: list[dict[str, str]] = []
+    for dirpath, _, filenames in os.walk(path):
+        for name in filenames:
+            fpath = os.path.join(dirpath, name)
+            try:
+                with open(fpath, "r", encoding="utf-8") as fh:
+                    text = fh.read().strip()
+            except OSError:
+                continue
+            if text.startswith("```"):
+                lines = text.splitlines()
+                if lines:
+                    lines = lines[1:]
+                if lines and lines[-1].startswith("```"):
+                    lines = lines[:-1]
+                text = "\n".join(lines)
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            for chain, info in data.items():
+                if isinstance(info, dict) and info.get("user_controlled") == "yes":
+                    matches.append(
+                        {
+                            "file": fpath,
+                            "call": chain,
+                            "evidence": info.get("evidence", ""),
+                        }
+                    )
+    print(json.dumps(matches, indent=2))
+
+
 def _run_findings_mode(args) -> None:
     with open(args.template, "r", encoding="utf-8") as f:
         template = f.read()
@@ -94,7 +127,9 @@ def _run_findings_mode(args) -> None:
 
 def main() -> None:
     args = parse_args()
-
+    if getattr(args, "scan_paramtrace", None):
+        _run_paramtrace_scan(args.scan_paramtrace)
+        return
     if args.security_audit:
         run_security_audit(args)
         return

--- a/tests/test_paramtrace_scan.py
+++ b/tests/test_paramtrace_scan.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import json
+import tempfile
+import unittest
+import unittest.mock
+import subprocess
+
+import codexdispatch as dispatch
+
+
+class TestParamtraceArgs(unittest.TestCase):
+    def test_parse_scan_paramtrace(self):
+        argv = ["dispatch.py", "--scan-paramtrace", "dir"]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = dispatch.parse_args()
+        self.assertEqual(args.scan_paramtrace, "dir")
+
+
+class TestParamtraceScan(unittest.TestCase):
+    def test_scan_outputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sample = os.path.join(tmp, "file-codex")
+            content = (
+                """```json\n{\n  \"a -> b\": {\n    \"user_controlled\": \"yes\",\n    \"evidence\": \"ev\"\n  },\n  \"c -> d\": {\n    \"user_controlled\": \"no\"\n  }\n}\n```"""
+            )
+            with open(sample, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            out = subprocess.check_output([
+                sys.executable,
+                "dispatch.py",
+                "--scan-paramtrace",
+                tmp,
+            ])
+            data = json.loads(out.decode())
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]["file"], sample)
+            self.assertEqual(data[0]["call"], "a -> b")
+


### PR DESCRIPTION
## Summary
- add `--scan-paramtrace` mode to dispatch for parsing Codex paramtrace outputs
- implement recursive scanner that extracts entries where `user_controlled` is `yes`
- test parsing and scanning behavior

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eb2cc56908324aaaf5de8522be340