### PR TITLE
Update paramtrace scan output fields

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -41,7 +41,8 @@ def _run_paramtrace_scan(path: str) -> None:
                     matches.append(
                         {
                             "file": fpath,
-                            "call": chain,
+                            "param": chain,
+                            "trace": info.get("trace", ""),
                             "evidence": info.get("evidence", ""),
                         }
                     )

--- a/tests/test_paramtrace_scan.py
+++ b/tests/test_paramtrace_scan.py
@@ -21,9 +21,18 @@ class TestParamtraceScan(unittest.TestCase):
     def test_scan_outputs(self):
         with tempfile.TemporaryDirectory() as tmp:
             sample = os.path.join(tmp, "file-codex")
-            content = (
-                """```json\n{\n  \"a -> b\": {\n    \"user_controlled\": \"yes\",\n    \"evidence\": \"ev\"\n  },\n  \"c -> d\": {\n    \"user_controlled\": \"no\"\n  }\n}\n```"""
-            )
+            content = """```json
+{
+  \"a -> b\": {
+    \"user_controlled\": \"yes\",
+    \"evidence\": \"ev\",
+    \"trace\": \"tr\"
+  },
+  \"c -> d\": {
+    \"user_controlled\": \"no\"
+  }
+}
+```"""
             with open(sample, "w", encoding="utf-8") as fh:
                 fh.write(content)
             out = subprocess.check_output([
@@ -35,5 +44,6 @@ class TestParamtraceScan(unittest.TestCase):
             data = json.loads(out.decode())
             self.assertEqual(len(data), 1)
             self.assertEqual(data[0]["file"], sample)
-            self.assertEqual(data[0]["call"], "a -> b")
+            self.assertEqual(data[0]["param"], "a -> b")
+            self.assertEqual(data[0]["trace"], "tr")
 


### PR DESCRIPTION
## Summary
- Rename `call` key to `param` for `--scan-paramtrace` output
- Surface `trace` information from the source JSON in scan results
- Align paramtrace tests with new output format

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb76338cc832493192e4b1e655c8a