### PR TITLE
Update findings mode work directory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ python dispatch.py TEMPLATE --file-list LIST --output-dir OUT --workers N -C WOR
 - `--file-list` - text file containing paths to process, one per line (file-list mode). In security audit mode entries may be either files or directories.
 - `--output-dir` - directory where results will be written.
 - `--workers` - number of parallel workers.
-- `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current directory. In file-list mode this directory is used for all files; in tree mode the default is each file's parent.
+- `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current
+  directory. In file-list mode this directory is used for all files. In tree mode
+  the default is each file's parent. When using `--findings-json`, each file runs in
+  its own parent directory and `-C`/`--work-dir` is not allowed.
 - `--recursive` / `--no-recursive` - control whether tree mode walks subdirectories (default: recursive).
 - `--codex-bin` - path to the codex binary. If not provided, the script looks for
   `codex` in `PATH` and then searches the current directory.

--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -169,8 +169,10 @@ def parse_args() -> argparse.Namespace:
             parser.error("--depth must be >= 1")
         if args.passes != 1:
             parser.error("--passes is not supported with --security-audit")
-    if args.findings_json and not args.work_dir:
-        parser.error("--work-dir is required with --findings-json")
-    if args.work_dir is None:
-        args.work_dir = os.getcwd()
+    if args.findings_json:
+        if args.work_dir:
+            parser.error("--work-dir is not allowed with --findings-json")
+    else:
+        if args.work_dir is None:
+            args.work_dir = os.getcwd()
     return args

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -101,6 +101,7 @@ def _run_findings_mode(args) -> None:
         )
         out_path = os.path.join(args.output_dir, slug, f"{rel_out}-codex")
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        work_dir = os.path.dirname(path)
         cmd = [
             codex_bin,
             "exec",
@@ -109,7 +110,7 @@ def _run_findings_mode(args) -> None:
             "--dangerously-bypass-approvals-and-sandbox",
             "--skip-git-repo-check",
             "-C",
-            args.work_dir,
+            work_dir,
         ]
         logging.info("FindingsMode: %s -> %s", path, out_path)
         try:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -102,14 +102,13 @@ class TestParseArgs(unittest.TestCase):
             "out",
             "-j",
             "1",
-            "-C",
-            "wd",
         ]
         with unittest.mock.patch.object(sys, "argv", argv):
             args = dispatch.parse_args()
         self.assertEqual(args.findings_json, "find.json")
+        self.assertIsNone(args.work_dir)
 
-    def test_findings_requires_workdir(self):
+    def test_findings_rejects_workdir(self):
         argv = [
             "dispatch.py",
             "tmpl",
@@ -119,6 +118,8 @@ class TestParseArgs(unittest.TestCase):
             "out",
             "-j",
             "1",
+            "-C",
+            "wd",
         ]
         with unittest.mock.patch.object(sys, "argv", argv):
             with self.assertRaises(SystemExit):
@@ -314,8 +315,6 @@ class DispatchIntegration(unittest.TestCase):
             outdir,
             "-j",
             "1",
-            "-C",
-            self.workdir,
             "--codex-bin",
             self.codex,
         ])
@@ -328,7 +327,7 @@ class DispatchIntegration(unittest.TestCase):
                 f"TEMPLATE\n{{\n  \"method\": \"m\"\n}}\n{os.path.abspath(src_file)}\nSRC",
             )
         with open(out_file + ".workdir", "r", encoding="utf-8") as f:
-            self.assertEqual(f.read(), self.workdir)
+            self.assertEqual(f.read(), os.path.dirname(src_file))
 
     def test_multi_pass_tree_dirs(self):
         template = os.path.join(self.tmpdir.name, "tmpl.txt")


### PR DESCRIPTION
## Summary
- disallow `--work-dir` when using `--findings-json`
- run each findings file with Codex in its parent directory
- document and test per-file working directories in findings mode

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ebbc467f4832482abf969823c649c