### PR TITLE
Add per-file workdir option for file-list mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ python dispatch.py TEMPLATE --file-list LIST --output-dir OUT --workers N -C WOR
 - `--output-dir` - directory where results will be written.
 - `--workers` - number of parallel workers.
 - `-C`, `--work-dir` - working directory to execute Codex in. Defaults to the current
-  directory. In file-list mode this directory is used for all files. In tree mode
-  the default is each file's parent. When using `--findings-json`, each file runs in
-  its own parent directory and `-C`/`--work-dir` is not allowed.
+  directory. In file-list mode this directory is used for all files unless
+  `--per-file-workdir` is supplied, which runs each file from its parent directory.
+  In tree mode the default is each file's parent. When using `--findings-json`, each
+  file runs in its own parent directory and `-C`/`--work-dir` is not allowed.
+- `--per-file-workdir` - in file-list mode set `-C` to each file's parent directory;
+  this disables shared-context imports across files.
 - `--recursive` / `--no-recursive` - control whether tree mode walks subdirectories (default: recursive).
 - `--codex-bin` - path to the codex binary. If not provided, the script looks for
   `codex` in `PATH` and then searches the current directory.
@@ -29,7 +32,7 @@ python dispatch.py TEMPLATE --file-list LIST --output-dir OUT --workers N -C WOR
 
 In flat mode, each file in `DATA_DIR` is appended to the template and sent to Codex. In tree mode every file discovered under `--tree-dirs` is processed the same way, with its parent directory used as the working directory. Results mirror the source tree: a file `src/example.txt` will produce `OUTPUT_DIR/src/example.txt-codex`. This avoids collisions when different directories contain files with the same name.
 
-File-list mode reads paths from a text file and processes exactly those files. By default each prompt contains the full resolved path on a separate line before its contents. Provide `--no-prepend-path` to omit this line. The working directory provided via `-C` is used for all Codex executions, which can be helpful when a shared virtual environment or imports are needed.
+File-list mode reads paths from a text file and processes exactly those files. By default each prompt contains the full resolved path on a separate line before its contents. Provide `--no-prepend-path` to omit this line. The working directory provided via `-C` is used for all Codex executions. Add `--per-file-workdir` to instead run each file from its own directory, noting that this prevents shared-context imports across files.
 
 With `--output-dir` and `--workers` provided as options, arguments can be specified in any order.
 

--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -114,6 +114,12 @@ def parse_args() -> argparse.Namespace:
         help="working directory to run Codex in (default: current directory)",
     )
     parser.add_argument(
+        "--per-file-workdir",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="in --file-list mode, set -C to the parent directory of each file",
+    )
+    parser.add_argument(
         "--timeout",
         type=int,
         default=int(os.getenv("CODEX_DISPATCH_TIMEOUT", 900)),

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -1,4 +1,8 @@
-"""Dispatches Codex runs across multiple files and modes, coordinating workers and multi-pass processing."""
+"""Dispatches Codex runs across multiple files and modes, coordinating workers and multi-pass processing.
+
+TODO(#123): track per-file workdir enhancements.
+See https://github.com/sourcegraph/codexdispatch/issues/123 for details.
+"""
 
 import os
 import sys
@@ -310,9 +314,14 @@ def main() -> None:
             output_path = os.path.join(output_dir, file_name)
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-            work_dir = args.work_dir if args.file_list else (
-                os.path.dirname(path) if args.tree_dirs else args.work_dir
-            )
+            if args.file_list:
+                work_dir = (
+                    os.path.dirname(path)
+                    if args.per_file_workdir or args.work_dir is None
+                    else args.work_dir
+                )
+            else:
+                work_dir = os.path.dirname(path) if args.tree_dirs else args.work_dir
             cmd = [
                 codex_bin,
                 "exec",

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -75,6 +75,23 @@ class TestParseArgs(unittest.TestCase):
         self.assertIsNone(args.data_dir)
         self.assertIsNone(args.tree_dirs)
         self.assertTrue(args.prepend_path)
+        self.assertFalse(args.per_file_workdir)
+
+    def test_parse_per_file_workdir(self):
+        argv = [
+            "dispatch.py",
+            "tmpl",
+            "--file-list",
+            "list.txt",
+            "-o",
+            "out",
+            "-j",
+            "1",
+            "--per-file-workdir",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = dispatch.parse_args()
+        self.assertTrue(args.per_file_workdir)
 
     def test_parse_no_prepend_path(self):
         argv = [
@@ -124,6 +141,110 @@ class TestParseArgs(unittest.TestCase):
         with unittest.mock.patch.object(sys, "argv", argv):
             with self.assertRaises(SystemExit):
                 dispatch.parse_args()
+
+
+class TestWorkDirSelection(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.template = os.path.join(self.tmpdir.name, "tmpl.txt")
+        with open(self.template, "w", encoding="utf-8") as f:
+            f.write("T")
+        self.subdir = os.path.join(self.tmpdir.name, "sub")
+        os.mkdir(self.subdir)
+        self.file = os.path.join(self.subdir, "file.txt")
+        with open(self.file, "w", encoding="utf-8") as f:
+            f.write("X")
+        self.listfile = os.path.join(self.tmpdir.name, "list.txt")
+        with open(self.listfile, "w", encoding="utf-8") as f:
+            f.write(self.file + "\n")
+        self.outdir = os.path.join(self.tmpdir.name, "out")
+        os.mkdir(self.outdir)
+
+    def _dispatch_and_capture(self, extra_args):
+        argv = [
+            "dispatch.py",
+            self.template,
+            "--file-list",
+            self.listfile,
+            "-o",
+            self.outdir,
+            "-j",
+            "1",
+        ] + extra_args
+        captured = {}
+
+        def fake_invoke(cmd, prompt, timeout, path):
+            captured[path] = cmd[cmd.index("-C") + 1]
+
+        with unittest.mock.patch.object(sys, "argv", argv), \
+            unittest.mock.patch("codexdispatch.dispatcher.find_codex_bin", return_value="codex"), \
+            unittest.mock.patch("codexdispatch.dispatcher._invoke_codex", side_effect=fake_invoke):
+            dispatch.main()
+        return captured[self.file]
+
+    def test_workdir_combinations(self):
+        cwd = os.getcwd()
+        self.assertEqual(self._dispatch_and_capture([]), cwd)
+        self.assertEqual(
+            self._dispatch_and_capture(["-C", self.tmpdir.name]),
+            self.tmpdir.name,
+        )
+        self.assertEqual(
+            self._dispatch_and_capture(["--per-file-workdir"]),
+            self.subdir,
+        )
+        self.assertEqual(
+            self._dispatch_and_capture(["-C", self.tmpdir.name, "--per-file-workdir"]),
+            self.subdir,
+        )
+
+
+class PerFileWorkDirIntegration(unittest.TestCase):
+    def test_per_file_workdir_two_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            template = os.path.join(tmp, "tmpl.txt")
+            with open(template, "w", encoding="utf-8") as f:
+                f.write("T")
+            dir_a = os.path.join(tmp, "a")
+            dir_b = os.path.join(tmp, "b")
+            os.mkdir(dir_a)
+            os.mkdir(dir_b)
+            file_a = os.path.join(dir_a, "a.txt")
+            file_b = os.path.join(dir_b, "b.txt")
+            with open(file_a, "w", encoding="utf-8") as f:
+                f.write("A")
+            with open(file_b, "w", encoding="utf-8") as f:
+                f.write("B")
+            lst = os.path.join(tmp, "list.txt")
+            with open(lst, "w", encoding="utf-8") as f:
+                f.write(file_a + "\n" + file_b + "\n")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                template,
+                "--file-list",
+                lst,
+                "-o",
+                outdir,
+                "-j",
+                "2",
+                "--per-file-workdir",
+            ]
+            captured: dict[str, str] = {}
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured[path] = cmd[cmd.index("-C") + 1]
+
+            with unittest.mock.patch.object(sys, "argv", argv), \
+                unittest.mock.patch("codexdispatch.dispatcher.find_codex_bin", return_value="codex"), \
+                unittest.mock.patch("codexdispatch.dispatcher._invoke_codex", side_effect=fake_invoke):
+                dispatch.main()
+
+            self.assertEqual(captured[file_a], dir_a)
+            self.assertEqual(captured[file_b], dir_b)
 
 
 class DispatchIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `--per-file-workdir` CLI flag
- run each file from its parent directory when requested
- document flag and update tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f01c6dad48324af0c59fb28ea7d43