### PR TITLE
Add phase mode for multi-template processing

### DIFF
--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -155,8 +155,40 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="recursively scan directory for paramtrace outputs",
     )
+    parser.add_argument(
+        "--phase-mode",
+        action="store_true",
+        default=False,
+        help="enable multi-phase processing using numbered templates",
+    )
+    parser.add_argument(
+        "--phase-templates",
+        dest="phase_templates",
+        default=None,
+        help="directory containing phase template files named 1,2,3,...",
+    )
+    parser.add_argument(
+        "--phase-workdir",
+        dest="phase_workdir",
+        default=None,
+        help="working directory for phases after the first",
+    )
+    parser.add_argument(
+        "--initial-files",
+        dest="initial_files",
+        default=None,
+        help="text file listing initial files or directories for phase mode",
+    )
     args = parser.parse_args()
     if args.scan_paramtrace:
+        return args
+    if args.phase_mode:
+        if not args.phase_templates or not args.initial_files:
+            parser.error("--phase-templates and --initial-files are required with --phase-mode")
+        if args.output_dir is None or args.workers is None:
+            parser.error("--output-dir and --workers are required")
+        if not args.phase_workdir:
+            parser.error("--phase-workdir is required with --phase-mode")
         return args
     if args.template is None:
         parser.error("template is required")

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -136,6 +136,109 @@ def _run_paramtrace_scan(path: str) -> None:
     print(json.dumps(matches, indent=2))
 
 
+def _run_phase_mode(args) -> None:
+    template_files = [f for f in os.listdir(args.phase_templates) if f.isdigit()]
+    phases = sorted(int(f) for f in template_files)
+    if not phases:
+        logging.error("PhaseMode: no templates found in %s", args.phase_templates)
+        return
+
+    with open(args.initial_files, "r", encoding="utf-8") as fh:
+        entries = [e.strip() for e in fh if e.strip() and not e.strip().startswith("#")]
+
+    inputs: list[str] = []
+    for entry in entries:
+        if os.path.isdir(entry):
+            for dirpath, _, filenames in os.walk(entry):
+                for name in filenames:
+                    path = os.path.join(dirpath, name)
+                    if os.path.isfile(path):
+                        inputs.append(path)
+        elif os.path.isfile(entry):
+            inputs.append(entry)
+        else:
+            logging.warning("PhaseMode: missing path %s", entry)
+
+    inputs = sorted(dict.fromkeys(inputs))
+    if not inputs:
+        logging.error("PhaseMode: no input files found")
+        return
+
+    codex_bin = find_codex_bin(args.codex_bin)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    first_phase = phases[0]
+    for phase in phases:
+        template_path = os.path.join(args.phase_templates, str(phase))
+        try:
+            with open(template_path, "r", encoding="utf-8") as tf:
+                template = tf.read()
+        except OSError as exc:
+            logging.error("PhaseMode: failed reading template %s: %s", template_path, exc)
+            return
+
+        out_root = os.path.join(args.output_dir, str(phase))
+        os.makedirs(out_root, exist_ok=True)
+
+        def worker(path: str):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+            except UnicodeDecodeError:
+                logging.warning("PhaseMode: skipping non-text file %s", path)
+                return None
+            except OSError as exc:
+                logging.error("PhaseMode: failed reading %s: %s", path, exc)
+                return None
+            full_path = os.path.abspath(path)
+            prompt = f"{template}\n{full_path}\n{data}"
+            rel_path = os.path.abspath(path)
+            rel_path = os.path.splitdrive(rel_path)[1].lstrip(os.sep)
+            if not rel_path.endswith("-codex"):
+                rel_path = f"{rel_path}-codex"
+            out_path = os.path.join(out_root, rel_path)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            work_dir = os.path.dirname(path) if phase == first_phase else args.phase_workdir
+            cmd = [
+                codex_bin,
+                "exec",
+                "--output-last-message",
+                out_path,
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--skip-git-repo-check",
+                "-C",
+                work_dir,
+            ]
+            logging.info(
+                "PhaseMode: phase=%s file=%s work_dir=%s -> %s",
+                phase,
+                path,
+                work_dir,
+                out_path,
+            )
+            try:
+                _invoke_codex(cmd, prompt, args.timeout, path)
+            except subprocess.TimeoutExpired as te:
+                logging.error("TIMEOUT after %ss on %s", te.timeout, path)
+                return None
+            except subprocess.CalledProcessError as cpe:
+                stderr = (cpe.stderr or b"").decode(errors="ignore")
+                logging.error("Codex exit %s on %s\n%s", cpe.returncode, path, stderr)
+                return None
+            except Exception as exc:
+                logging.error("Failed processing %s: %s", path, exc)
+                return None
+            return out_path
+
+        with ThreadPoolExecutor(max_workers=args.workers) as ex:
+            results = list(ex.map(worker, inputs))
+
+        inputs = [r for r in results if r]
+        if not inputs:
+            logging.info("PhaseMode: no outputs produced for phase %s", phase)
+            break
+
+
 def _run_findings_mode(args) -> None:
     with open(args.template, "r", encoding="utf-8") as f:
         template = f.read()
@@ -224,6 +327,9 @@ def main() -> None:
         return
     if getattr(args, "findings_json", None):
         _run_findings_mode(args)
+        return
+    if getattr(args, "phase_mode", False):
+        _run_phase_mode(args)
         return
 
     template_path = args.template

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -142,6 +142,28 @@ class TestParseArgs(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 dispatch.parse_args()
 
+    def test_parse_phase_mode(self):
+        argv = [
+            "dispatch.py",
+            "--phase-mode",
+            "--phase-templates",
+            "tmpldir",
+            "--phase-workdir",
+            "wd",
+            "--initial-files",
+            "files.txt",
+            "-o",
+            "out",
+            "-j",
+            "2",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = dispatch.parse_args()
+        self.assertTrue(args.phase_mode)
+        self.assertEqual(args.phase_templates, "tmpldir")
+        self.assertEqual(args.phase_workdir, "wd")
+        self.assertEqual(args.initial_files, "files.txt")
+
 
 class TestWorkDirSelection(unittest.TestCase):
     def setUp(self):
@@ -245,6 +267,67 @@ class PerFileWorkDirIntegration(unittest.TestCase):
 
             self.assertEqual(captured[file_a], dir_a)
             self.assertEqual(captured[file_b], dir_b)
+
+
+class PhaseModeIntegration(unittest.TestCase):
+    def test_phase_mode_two_phases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpl_dir = os.path.join(tmp, "tmpl")
+            os.mkdir(tmpl_dir)
+            with open(os.path.join(tmpl_dir, "1"), "w", encoding="utf-8") as f:
+                f.write("T1")
+            with open(os.path.join(tmpl_dir, "2"), "w", encoding="utf-8") as f:
+                f.write("T2")
+            file_a = os.path.join(tmp, "a.txt")
+            with open(file_a, "w", encoding="utf-8") as f:
+                f.write("A")
+            subdir = os.path.join(tmp, "sub")
+            os.mkdir(subdir)
+            file_b = os.path.join(subdir, "b.txt")
+            with open(file_b, "w", encoding="utf-8") as f:
+                f.write("B")
+            lst = os.path.join(tmp, "list.txt")
+            with open(lst, "w", encoding="utf-8") as f:
+                f.write(file_a + "\n" + subdir + "\n")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+            phase_wd = os.path.join(tmp, "wd")
+            os.mkdir(phase_wd)
+
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--phase-templates",
+                tmpl_dir,
+                "--phase-workdir",
+                phase_wd,
+                "--initial-files",
+                lst,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            captured: dict[str, str] = {}
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                out = cmd[cmd.index("--output-last-message") + 1]
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("X")
+                captured[path] = cmd[cmd.index("-C") + 1]
+
+            with unittest.mock.patch.object(sys, "argv", argv), \
+                unittest.mock.patch("codexdispatch.dispatcher.find_codex_bin", return_value="codex"), \
+                unittest.mock.patch("codexdispatch.dispatcher._invoke_codex", side_effect=fake_invoke):
+                dispatch.main()
+
+            out_a = os.path.join(outdir, "1", os.path.abspath(file_a).lstrip(os.sep) + "-codex")
+            out_b = os.path.join(outdir, "1", os.path.abspath(file_b).lstrip(os.sep) + "-codex")
+            self.assertEqual(captured[file_a], os.path.dirname(file_a))
+            self.assertEqual(captured[file_b], os.path.dirname(file_b))
+            self.assertEqual(captured[out_a], phase_wd)
+            self.assertEqual(captured[out_b], phase_wd)
 
 
 class DispatchIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- support `--phase-mode` with numbered templates and initial file list
- iterate over outputs from previous phases in new `_run_phase_mode`
- add tests for phase mode argument parsing and execution

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890082ad5ec8324a0f30d719871b99d