### PR TITLE
Add resume processing for phase-mode with pre-supplied findings

### DIFF
--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -80,6 +80,11 @@ def parse_args() -> argparse.Namespace:
         dest="findings_json",
         help="GitLab findings.json input file",
     )
+    group.add_argument(
+        "--findings-list",
+        dest="findings_list",
+        help="text file containing paths to pre-supplied finding outputs",
+    )
     parser.add_argument(
         "--prepend-path",
         dest="prepend_path",
@@ -144,6 +149,12 @@ def parse_args() -> argparse.Namespace:
         help="mapping filename for multi-pass mode",
     )
     parser.add_argument(
+        "--findings-workdir",
+        dest="findings_workdir",
+        default=None,
+        help="working directory associated with entries from --findings-list",
+    )
+    parser.add_argument(
         "--relative-dir",
         dest="relative_dir",
         default=None,
@@ -184,6 +195,28 @@ def parse_args() -> argparse.Namespace:
     if args.scan_paramtrace:
         return args
     if args.phase_mode:
+        if args.findings_list:
+            if not args.findings_workdir:
+                parser.error("--findings-workdir is required with --findings-list")
+            if any(
+                [
+                    args.data_dir,
+                    args.tree_dirs,
+                    args.file_list,
+                    args.findings_json,
+                    args.audit_template,
+                ]
+            ):
+                parser.error(
+                    "--findings-list is incompatible with --data-dir, --tree-dirs, --file-list, --findings-json, and --audit-template"
+                )
+            if args.orchestrator_template is None:
+                parser.error("--orchestrator-template is required with --findings-list")
+            if args.output_dir is None or args.workers is None:
+                parser.error("--output-dir and --workers are required")
+            if not os.path.isdir(args.findings_workdir):
+                parser.error("--findings-workdir must be an existing directory")
+            return args
         if not args.audit_template or not args.orchestrator_template:
             parser.error("--audit-template and --orchestrator-template are required with --phase-mode")
         if not any([args.data_dir, args.tree_dirs, args.file_list, args.findings_json]):
@@ -193,6 +226,8 @@ def parse_args() -> argparse.Namespace:
         if args.output_dir is None or args.workers is None:
             parser.error("--output-dir and --workers are required")
         return args
+    if args.findings_list or args.findings_workdir:
+        parser.error("--findings-list and --findings-workdir require --phase-mode")
     if args.template is None:
         parser.error("template is required")
     if not any([args.data_dir, args.tree_dirs, args.file_list, args.findings_json]):

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -13,6 +13,7 @@ import json
 import re
 import hashlib
 import random
+import shutil
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional
@@ -150,10 +151,11 @@ def _run_paramtrace_scan(path: str) -> None:
 
 def _run_phase_mode(args) -> None:
     try:
-        with open(args.audit_template, "r", encoding="utf-8") as f:
-            audit_template = f.read()
         with open(args.orchestrator_template, "r", encoding="utf-8") as f:
             orchestrator_template = f.read()
+        if not args.findings_list:
+            with open(args.audit_template, "r", encoding="utf-8") as f:
+                audit_template = f.read()
     except OSError as exc:
         logging.error("PhaseMode: failed reading template: %s", exc)
         return
@@ -161,17 +163,6 @@ def _run_phase_mode(args) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     codex_bin = find_codex_bin(args.codex_bin)
 
-    if args.tree_dirs:
-        inputs = collect_files(args.tree_dirs, recursive=args.recursive)
-    elif args.data_dir:
-        inputs = load_files(args.data_dir)
-    elif args.file_list:
-        with open(args.file_list, "r", encoding="utf-8") as fh:
-            inputs = [p.strip() for p in fh if p.strip() and not p.strip().startswith("#")]
-    else:
-        inputs = []
-
-    inputs = sorted(dict.fromkeys(inputs))
     phase1_dir = os.path.join(args.output_dir, "phase_1")
     final_dir = os.path.join(args.output_dir, "final")
     os.makedirs(phase1_dir, exist_ok=True)
@@ -188,47 +179,86 @@ def _run_phase_mode(args) -> None:
     else:
         workdir_map = {}
 
-    # Phase 1 – run security audit
-    for path in inputs:
+    if args.findings_list:
         try:
-            with open(path, "r", encoding="utf-8") as f:
-                data = f.read()
-        except UnicodeDecodeError:
-            logging.warning("PhaseMode: skipping non-text file %s", path)
-            continue
+            with open(args.findings_list, "r", encoding="utf-8") as fh:
+                raw = [l.strip() for l in fh if l.strip() and not l.strip().startswith("#")]
         except OSError as exc:
-            logging.error("PhaseMode: failed reading %s: %s", path, exc)
-            continue
-        full_path = os.path.abspath(path)
-        prompt = f"{audit_template}\n{full_path}\n{data}"
-        rel_path = os.path.splitdrive(full_path)[1].lstrip(os.sep)
-        if not rel_path.endswith("-codex"):
-            rel_path = f"{rel_path}-codex"
-        out_path = os.path.join(phase1_dir, rel_path)
-        os.makedirs(os.path.dirname(out_path), exist_ok=True)
-        cmd = [
-            codex_bin,
-            "exec",
-            "--output-last-message",
-            out_path,
-            "--dangerously-bypass-approvals-and-sandbox",
-            "--skip-git-repo-check",
-            "-C",
-            os.path.dirname(path),
-        ]
-        logging.info("PhaseMode: phase_1 file=%s -> %s", path, out_path)
-        try:
-            _invoke_codex(cmd, prompt, args.timeout, path)
-        except subprocess.TimeoutExpired as te:
-            logging.error("TIMEOUT after %ss on %s", te.timeout, path)
-        except subprocess.CalledProcessError as cpe:
-            stderr = (cpe.stderr or b"").decode(errors="ignore")
-            logging.error("Codex exit %s on %s\n%s", cpe.returncode, path, stderr)
-        except Exception as exc:
-            logging.error("Failed processing %s: %s", path, exc)
-        workdir_map[out_path] = os.path.dirname(path)
+            logging.error("PhaseMode: failed reading findings list: %s", exc)
+            return
+        seen: set[str] = set()
+        inputs: List[str] = []
+        for p in raw:
+            if p not in seen:
+                seen.add(p)
+                inputs.append(p)
+        for src in inputs:
+            if not os.path.isfile(src):
+                logging.warning("PhaseMode: skipping missing finding %s", src)
+                continue
+            dest = os.path.join(phase1_dir, os.path.basename(src))
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            try:
+                shutil.copyfile(src, dest)
+            except OSError as exc:
+                logging.error("PhaseMode: failed copying %s: %s", src, exc)
+                continue
+            workdir_map[dest] = args.findings_workdir
         with open(workdirs_path, "w", encoding="utf-8") as wf:
             json.dump(workdir_map, wf)
+    else:
+        if args.tree_dirs:
+            inputs = collect_files(args.tree_dirs, recursive=args.recursive)
+        elif args.data_dir:
+            inputs = load_files(args.data_dir)
+        elif args.file_list:
+            with open(args.file_list, "r", encoding="utf-8") as fh:
+                inputs = [p.strip() for p in fh if p.strip() and not p.strip().startswith("#")]
+        else:
+            inputs = []
+        inputs = sorted(dict.fromkeys(inputs))
+
+        # Phase 1 – run security audit
+        for path in inputs:
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+            except UnicodeDecodeError:
+                logging.warning("PhaseMode: skipping non-text file %s", path)
+                continue
+            except OSError as exc:
+                logging.error("PhaseMode: failed reading %s: %s", path, exc)
+                continue
+            full_path = os.path.abspath(path)
+            prompt = f"{audit_template}\n{full_path}\n{data}"
+            rel_path = os.path.splitdrive(full_path)[1].lstrip(os.sep)
+            if not rel_path.endswith("-codex"):
+                rel_path = f"{rel_path}-codex"
+            out_path = os.path.join(phase1_dir, rel_path)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            cmd = [
+                codex_bin,
+                "exec",
+                "--output-last-message",
+                out_path,
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--skip-git-repo-check",
+                "-C",
+                os.path.dirname(path),
+            ]
+            logging.info("PhaseMode: phase_1 file=%s -> %s", path, out_path)
+            try:
+                _invoke_codex(cmd, prompt, args.timeout, path)
+            except subprocess.TimeoutExpired as te:
+                logging.error("TIMEOUT after %ss on %s", te.timeout, path)
+            except subprocess.CalledProcessError as cpe:
+                stderr = (cpe.stderr or b"").decode(errors="ignore")
+                logging.error("Codex exit %s on %s\n%s", cpe.returncode, path, stderr)
+            except Exception as exc:
+                logging.error("Failed processing %s: %s", path, exc)
+            workdir_map[out_path] = os.path.dirname(path)
+            with open(workdirs_path, "w", encoding="utf-8") as wf:
+                json.dump(workdir_map, wf)
 
     # Phase 2..N – orchestrator loop
     for dirpath, _, filenames in os.walk(phase1_dir):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -165,6 +165,65 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(args.file_list, "files.txt")
         self.assertEqual(args.max_inquiries, 3)
 
+    def test_findings_list_requires_workdir(self):
+        argv = [
+            "dispatch.py",
+            "--phase-mode",
+            "--orchestrator-template",
+            "orch.txt",
+            "--findings-list",
+            "list.txt",
+            "-o",
+            "out",
+            "-j",
+            "1",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit):
+                dispatch.parse_args()
+
+    def test_findings_list_conflicts(self):
+        argv = [
+            "dispatch.py",
+            "--phase-mode",
+            "--orchestrator-template",
+            "orch.txt",
+            "--findings-list",
+            "list.txt",
+            "--findings-workdir",
+            "wd",
+            "--tree-dirs",
+            "src",
+            "-o",
+            "out",
+            "-j",
+            "1",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit):
+                dispatch.parse_args()
+
+    def test_parse_findings_resume(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                "orch.txt",
+                "--findings-list",
+                "list.txt",
+                "--findings-workdir",
+                tmp,
+                "-o",
+                "out",
+                "-j",
+                "1",
+            ]
+            with unittest.mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+            self.assertEqual(args.findings_list, "list.txt")
+            self.assertEqual(args.findings_workdir, tmp)
+
 
 class TestWorkDirSelection(unittest.TestCase):
     def setUp(self):

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import unittest
 import unittest.mock as mock
+import hashlib
 
 import codexdispatch as dispatch
 import codexdispatch.dispatcher as dispatcher
@@ -100,6 +101,176 @@ class TestPhaseModeWorkflow(unittest.TestCase):
             second_cmd = captured_cmds[1]
             self.assertIn("-C", second_cmd)
             self.assertEqual(second_cmd[second_cmd.index("-C") + 1], os.path.dirname(src))
+
+    def test_presupplied_findings_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            f1 = os.path.join(tmp, "f1.json")
+            f2 = os.path.join(tmp, "f2.json")
+            for path, val in ((f1, "a"), (f2, "b")):
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(json.dumps({"finding": val}))
+            listfile = os.path.join(tmp, "findings.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(f1 + "\n")
+                fh.write("# comment\n")
+                fh.write(f2 + "\n")
+                fh.write(f1 + "\n")
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--findings-workdir",
+                workdir,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            def fake_find_codex_bin(path):
+                return "codex"
+
+            captured_cmds: list[list[str]] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [
+                {"conclusion": "valid"},
+                {"inquiry": "why?"},
+                {"conclusion": "invalid"},
+            ]
+
+            def fake_orchestrator(prompt):
+                return orch_responses.pop(0)
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
+                mock.patch("codexdispatch.dispatcher._invoke_codex", fake_invoke), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", fake_orchestrator):
+                dispatcher._run_phase_mode(args)
+
+            phase1_dir = os.path.join(outdir, "phase_1")
+            self.assertTrue(os.path.exists(os.path.join(phase1_dir, os.path.basename(f1))))
+            self.assertTrue(os.path.exists(os.path.join(phase1_dir, os.path.basename(f2))))
+            final_dir = os.path.join(outdir, "final")
+            self.assertTrue(os.path.exists(os.path.join(final_dir, os.path.basename(f1))))
+            self.assertTrue(os.path.exists(os.path.join(final_dir, os.path.basename(f2))))
+            phase2_meta = os.path.join(outdir, "phase_2", os.path.basename(f2)) + ".meta"
+            self.assertTrue(os.path.exists(phase2_meta))
+            with open(phase2_meta, "r", encoding="utf-8") as mf:
+                meta = json.load(mf)
+            self.assertEqual(meta["response"], "resp")
+            cache_dir = os.path.join(tmp, "cache")
+            with open(os.path.join(cache_dir, "workdirs.json"), "r", encoding="utf-8") as wf:
+                wd_map = json.load(wf)
+            self.assertEqual(
+                wd_map[os.path.join(phase1_dir, os.path.basename(f1))], workdir
+            )
+            self.assertEqual(len(captured_cmds), 1)
+
+    def test_cache_resume(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            finding = os.path.join(tmp, "f.json")
+            with open(finding, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({"finding": "x"}))
+            listfile = os.path.join(tmp, "findings.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(finding + "\n")
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--findings-workdir",
+                workdir,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            def fake_find_codex_bin(path):
+                return "codex"
+
+            captured_cmds: list[list[str]] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [{"inquiry": "why?"}]
+
+            def first_orchestrator(prompt):
+                if orch_responses:
+                    return orch_responses.pop(0)
+                raise IndexError
+
+            try:
+                with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
+                    mock.patch("codexdispatch.dispatcher._invoke_codex", fake_invoke), \
+                    mock.patch("codexdispatch.dispatcher.call_orchestrator", first_orchestrator):
+                    dispatcher._run_phase_mode(args)
+            except IndexError:
+                pass
+
+            phase1_file = os.path.join(outdir, "phase_1", os.path.basename(finding))
+            cache_dir = os.path.join(tmp, "cache")
+            cache_key = hashlib.sha256(phase1_file.encode()).hexdigest()
+            cache_path = os.path.join(cache_dir, f"{cache_key}.json")
+            with open(cache_path, "r", encoding="utf-8") as cf:
+                data = json.load(cf)
+            self.assertEqual(data["status"], "open")
+            self.assertEqual(len(captured_cmds), 1)
+
+            orch_responses2 = [{"conclusion": "valid"}]
+
+            def second_orchestrator(prompt):
+                return orch_responses2.pop(0)
+
+            captured_cmds2: list[list[str]] = []
+
+            def fake_invoke2(cmd, prompt, timeout, path):
+                captured_cmds2.append(list(cmd))
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
+                mock.patch("codexdispatch.dispatcher._invoke_codex", fake_invoke2), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", second_orchestrator):
+                dispatcher._run_phase_mode(args)
+
+            final_file = os.path.join(outdir, "final", os.path.basename(finding))
+            self.assertTrue(os.path.exists(final_file))
+            with open(cache_path, "r", encoding="utf-8") as cf:
+                data = json.load(cf)
+            self.assertEqual(data["status"], "concluded")
+            self.assertEqual(len(captured_cmds2), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support `--findings-list`/`--findings-workdir` for phase-mode resume runs
- allow dispatcher to ingest existing findings and continue orchestrator loop
- add comprehensive tests for new resume mode and cache recovery

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890267867548324975f1e7105b42e07