### PR TITLE
Add OpenAI helper and integrate orchestrator call

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -25,6 +25,49 @@ from .security_audit import run_security_audit
 
 def call_orchestrator(prompt: str) -> dict:
     """Return {"inquiry": "..."} or {"conclusion": "valid|invalid"}."""
+    try:
+        from . import openai_stub
+
+        schema = [
+            {
+                "name": "orchestrator_decision",
+                "description": "Ask for more information or conclude the audit.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "inquiry": {"type": "string"},
+                        "conclusion": {
+                            "type": "string",
+                            "enum": ["valid", "invalid"],
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            }
+        ]
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a security audit orchestrator. Use the"
+                    " orchestrator_decision function to either request"
+                    " further details or conclude whether the finding is"
+                    " valid or invalid."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+        response = openai_stub.openai_generate_response(
+            messages=messages, functions=schema
+        )
+        name, data = openai_stub.openai_parse_function_call(response)
+        if name == "orchestrator_decision" and isinstance(data, dict):
+            if "inquiry" in data:
+                return {"inquiry": data["inquiry"]}
+            if "conclusion" in data:
+                return {"conclusion": data["conclusion"]}
+    except Exception as exc:  # pragma: no cover - fallback path
+        logging.warning("call_orchestrator falling back to stub: %s", exc)
     # This stub randomly concludes or asks for more details to exercise both
     # branches during tests without requiring real API calls.
     if random.random() < 0.3:

--- a/codexdispatch/openai_stub.py
+++ b/codexdispatch/openai_stub.py
@@ -1,0 +1,76 @@
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+_client = None
+
+
+def openai_configure_api(api_key: Optional[str] = None):
+    """Retrieve key, build global client, log success.
+
+    Returns the configured OpenAI client or ``None`` if configuration fails.
+    """
+    global _client
+    if _client is not None:
+        return _client
+    try:
+        from openai import OpenAI
+    except Exception as exc:  # pragma: no cover - import failure path
+        logging.warning("openai package not available: %s", exc)
+        return None
+    key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        logging.warning("OPENAI_API_KEY is not set")
+        return None
+    _client = OpenAI(api_key=key)
+    logging.info("OpenAI client configured")
+    return _client
+
+
+def openai_generate_response(
+    *,
+    messages: List[Dict[str, str]],
+    functions: Optional[List[Dict[str, Any]]] = None,
+    function_call: Optional[str | Dict[str, str]] = "auto",
+    model: str = "o3-mini",
+    reasoning_effort: str = "high",
+    service_tier: str = "flex",
+    **extra: Any,
+):
+    """Wrapper around ``client.chat.completions.create`` with defaults."""
+    client = openai_configure_api()
+    if client is None:
+        raise RuntimeError("OpenAI client is not configured")
+    params: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "reasoning_effort": reasoning_effort,
+        "service_tier": service_tier,
+        **extra,
+    }
+    if functions:
+        params["functions"] = functions
+        if function_call is not None:
+            params["function_call"] = function_call
+    logging.info("Sending:\n%s", messages)
+    response = client.chat.completions.create(**params)
+    logging.info("Received:\n%s", response)
+    return response
+
+
+def openai_parse_function_call(response: Any) -> Tuple[Optional[str], Any]:
+    """Extract function call data from a chat completion response."""
+    choice = response.choices[0] if response.choices else None
+    msg = getattr(choice, "message", None) if choice else None
+    fc = getattr(msg, "function_call", None) if msg else None
+    if not fc:
+        return None, None
+    name = getattr(fc, "name", None)
+    args_str = getattr(fc, "arguments", "") or "{}"
+    try:
+        data = json.loads(args_str)
+    except json.JSONDecodeError:
+        data = {}
+    logging.info("Function call %s with %s", name, data)
+    return name, data

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -1,0 +1,25 @@
+import json
+import types
+import unittest
+from unittest import mock
+
+import codexdispatch.dispatcher as dispatcher
+
+
+class TestCallOrchestrator(unittest.TestCase):
+    def test_uses_openai_stub(self):
+        def fake_generate_response(*args, **kwargs):
+            fc = types.SimpleNamespace(
+                name="orchestrator_decision",
+                arguments=json.dumps({"conclusion": "valid"}),
+            )
+            msg = types.SimpleNamespace(function_call=fc)
+            choice = types.SimpleNamespace(message=msg)
+            return types.SimpleNamespace(choices=[choice])
+
+        with mock.patch(
+            "codexdispatch.openai_stub.openai_generate_response",
+            side_effect=fake_generate_response,
+        ):
+            result = dispatcher.call_orchestrator("prompt")
+        self.assertEqual(result, {"conclusion": "valid"})


### PR DESCRIPTION
## Summary
- add OpenAI helper module offering configuration, response generation, and function-call parsing
- wire dispatcher orchestrator to OpenAI helpers with function schema and stub fallback
- add unit test covering OpenAI path in orchestrator

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890450af7cc8324972076453154118f