### PR TITLE
Use o3 orchestrator model with flex tier

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -58,7 +58,11 @@ def call_orchestrator(prompt: str) -> dict:
             {"role": "user", "content": prompt},
         ]
         response = openai_stub.openai_generate_response(
-            messages=messages, functions=schema
+            messages=messages,
+            functions=schema,
+            model="o3",
+            service_tier="flex",
+            reasoning_effort="high",
         )
         name, data = openai_stub.openai_parse_function_call(response)
         if name == "orchestrator_decision" and isinstance(data, dict):
@@ -305,7 +309,7 @@ def _run_phase_mode(args) -> None:
 
     # Phase 2..N – orchestrator loop
     for dirpath, _, filenames in os.walk(phase1_dir):
-        for name in filenames:
+        for name in sorted(filenames):
             finding_path = os.path.join(dirpath, name)
             rel = os.path.relpath(finding_path, phase1_dir)
             cache_key = hashlib.sha256(finding_path.encode()).hexdigest()

--- a/codexdispatch/openai_stub.py
+++ b/codexdispatch/openai_stub.py
@@ -33,7 +33,7 @@ def openai_generate_response(
     messages: List[Dict[str, str]],
     functions: Optional[List[Dict[str, Any]]] = None,
     function_call: Optional[str | Dict[str, str]] = "auto",
-    model: str = "o3-mini",
+    model: str = "o3",
     reasoning_effort: str = "high",
     service_tier: str = "flex",
     **extra: Any,

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -8,18 +8,23 @@ import codexdispatch.dispatcher as dispatcher
 
 class TestCallOrchestrator(unittest.TestCase):
     def test_uses_openai_stub(self):
-        def fake_generate_response(*args, **kwargs):
-            fc = types.SimpleNamespace(
-                name="orchestrator_decision",
-                arguments=json.dumps({"conclusion": "valid"}),
-            )
-            msg = types.SimpleNamespace(function_call=fc)
-            choice = types.SimpleNamespace(message=msg)
-            return types.SimpleNamespace(choices=[choice])
+        fc = types.SimpleNamespace(
+            name="orchestrator_decision",
+            arguments=json.dumps({"conclusion": "valid"}),
+        )
+        msg = types.SimpleNamespace(function_call=fc)
+        choice = types.SimpleNamespace(message=msg)
+        mock_response = types.SimpleNamespace(choices=[choice])
 
         with mock.patch(
             "codexdispatch.openai_stub.openai_generate_response",
-            side_effect=fake_generate_response,
-        ):
+            return_value=mock_response,
+        ) as mock_gen:
             result = dispatcher.call_orchestrator("prompt")
+
         self.assertEqual(result, {"conclusion": "valid"})
+        mock_gen.assert_called_once()
+        _, kwargs = mock_gen.call_args
+        self.assertEqual(kwargs["model"], "o3")
+        self.assertEqual(kwargs["service_tier"], "flex")
+        self.assertEqual(kwargs["reasoning_effort"], "high")


### PR DESCRIPTION
## Summary
- Default orchestrator calls now use the `o3` model with `flex` service tier and `high` reasoning effort.
- Ensure phase mode processes findings in a stable order.
- Add tests asserting orchestrator calls include model, tier, and reasoning effort.

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689047af6b9083248cd1d8353f6c965b