### PR TITLE
Add reasoning summaries to orchestrator conclusions

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -24,7 +24,7 @@ from .security_audit import run_security_audit
 
 
 def call_orchestrator(prompt: str) -> dict:
-    """Return {"inquiry": "..."} or {"conclusion": "valid|invalid"}."""
+    """Return {"inquiry": "..."} or {"conclusion": "valid|invalid", "summary": "..."}."""
     try:
         from . import openai_stub
 
@@ -40,6 +40,7 @@ def call_orchestrator(prompt: str) -> dict:
                             "type": "string",
                             "enum": ["valid", "invalid"],
                         },
+                        "summary": {"type": "string"},
                     },
                     "additionalProperties": False,
                 },
@@ -52,7 +53,8 @@ def call_orchestrator(prompt: str) -> dict:
                     "You are a security audit orchestrator. Use the"
                     " orchestrator_decision function to either request"
                     " further details or conclude whether the finding is"
-                    " valid or invalid."
+                    " valid or invalid. When concluding, provide a concise"
+                    " reasoning summary in the 'summary' field."
                 ),
             },
             {"role": "user", "content": prompt},
@@ -69,13 +71,19 @@ def call_orchestrator(prompt: str) -> dict:
             if "inquiry" in data:
                 return {"inquiry": data["inquiry"]}
             if "conclusion" in data:
-                return {"conclusion": data["conclusion"]}
+                return {
+                    "conclusion": data["conclusion"],
+                    "summary": data.get("summary", ""),
+                }
     except Exception as exc:  # pragma: no cover - fallback path
         logging.warning("call_orchestrator falling back to stub: %s", exc)
     # This stub randomly concludes or asks for more details to exercise both
     # branches during tests without requiring real API calls.
     if random.random() < 0.3:
-        return {"conclusion": random.choice(["valid", "invalid"])}
+        return {
+            "conclusion": random.choice(["valid", "invalid"]),
+            "summary": "stub conclusion",
+        }
     return {"inquiry": "Provide precise reproduction steps for this finding."}
 
 

--- a/orchestrator.txt
+++ b/orchestrator.txt
@@ -43,12 +43,14 @@ or
 
 ```json
 {
-  "conclusion": "valid|invalid|inconclusive"
-}
-```
+    "conclusion": "valid|invalid|inconclusive",
+    "summary": "<brief reasoning>"
+  }
+ ```
 
 CONSTRAINTS
 • Return **only** one valid JSON object as shown, minified (no comments, prose, or extra keys).
+• When providing a conclusion also supply a concise logical summary in `summary`.
 • Stop asking questions when a verdict can be made or when inquiry budget is exhausted.
 
 Put the JSON object alone on the final line, no trailing text.

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -372,7 +372,7 @@ class PhaseModeIntegration(unittest.TestCase):
                 captured.append(out)
 
             def fake_orchestrator(prompt):
-                return {"conclusion": "valid"}
+                return {"conclusion": "valid", "summary": "done"}
 
             with unittest.mock.patch.object(sys, "argv", argv), \
                 unittest.mock.patch("codexdispatch.dispatcher.find_codex_bin", return_value="codex"), \

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -10,7 +10,7 @@ class TestCallOrchestrator(unittest.TestCase):
     def test_uses_openai_stub(self):
         fc = types.SimpleNamespace(
             name="orchestrator_decision",
-            arguments=json.dumps({"conclusion": "valid"}),
+            arguments=json.dumps({"conclusion": "valid", "summary": "done"}),
         )
         msg = types.SimpleNamespace(function_call=fc)
         choice = types.SimpleNamespace(message=msg)
@@ -22,7 +22,7 @@ class TestCallOrchestrator(unittest.TestCase):
         ) as mock_gen:
             result = dispatcher.call_orchestrator("prompt")
 
-        self.assertEqual(result, {"conclusion": "valid"})
+        self.assertEqual(result, {"conclusion": "valid", "summary": "done"})
         mock_gen.assert_called_once()
         _, kwargs = mock_gen.call_args
         self.assertEqual(kwargs["model"], "o3")

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -62,7 +62,7 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                     with open(out, "w", encoding="utf-8") as fh:
                         fh.write(inquiry_output)
 
-            orch_responses = [{"inquiry": "why?"}, {"conclusion": "valid"}]
+            orch_responses = [{"inquiry": "why?"}, {"conclusion": "valid", "summary": "done"}]
 
             def fake_orchestrator(prompt):
                 return orch_responses.pop(0)
@@ -151,9 +151,9 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                     fh.write("resp")
 
             orch_responses = [
-                {"conclusion": "valid"},
+                {"conclusion": "valid", "summary": "done"},
                 {"inquiry": "why?"},
-                {"conclusion": "invalid"},
+                {"conclusion": "invalid", "summary": "oops"},
             ]
 
             def fake_orchestrator(prompt):
@@ -250,7 +250,7 @@ class TestPhaseModeWorkflow(unittest.TestCase):
             self.assertEqual(data["status"], "open")
             self.assertEqual(len(captured_cmds), 1)
 
-            orch_responses2 = [{"conclusion": "valid"}]
+            orch_responses2 = [{"conclusion": "valid", "summary": "done"}]
 
             def second_orchestrator(prompt):
                 return orch_responses2.pop(0)


### PR DESCRIPTION
## Summary
- require orchestrator to return a brief reasoning summary whenever it concludes
- document summary field in `orchestrator.txt`
- adjust tests for new orchestrator behaviour

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68904db9795083248955924428f57ee5