### PR TITLE
feat: enable web search for o3 responses

### DIFF
--- a/codexdispatch/openai_stub.py
+++ b/codexdispatch/openai_stub.py
@@ -38,32 +38,44 @@ def openai_generate_response(
     service_tier: str = "flex",
     **extra: Any,
 ):
-    """Wrapper around ``client.chat.completions.create`` with defaults."""
+    """Wrapper around ``client.responses.create`` with defaults.
+
+    ``function_call`` is retained for compatibility but ignored as the
+    Responses API decides when to invoke tools.
+    """
     client = openai_configure_api()
     if client is None:
         raise RuntimeError("OpenAI client is not configured")
+
+    tools: List[Dict[str, Any]] = [{"type": "web_search"}]
+    if functions:
+        tools.extend({"type": "function", "function": f} for f in functions)
+
     params: Dict[str, Any] = {
         "model": model,
-        "messages": messages,
-        "reasoning_effort": reasoning_effort,
+        "input": messages,
+        "tools": tools,
+        "reasoning": {"effort": reasoning_effort},
         "service_tier": service_tier,
         **extra,
     }
-    if functions:
-        params["functions"] = functions
-        if function_call is not None:
-            params["function_call"] = function_call
+
     logging.info("Sending:\n%s", messages)
-    response = client.chat.completions.create(**params)
+    response = client.responses.create(**params)
     logging.info("Received:\n%s", response)
     return response
 
 
 def openai_parse_function_call(response: Any) -> Tuple[Optional[str], Any]:
-    """Extract function call data from a chat completion response."""
-    choice = response.choices[0] if response.choices else None
-    msg = getattr(choice, "message", None) if choice else None
-    fc = getattr(msg, "function_call", None) if msg else None
+    """Extract function call data from a Responses API result."""
+    output = getattr(response, "output", None)
+    msg = output[0] if output else None
+    content = getattr(msg, "content", []) if msg else []
+    fc = None
+    for item in content:
+        if getattr(item, "type", None) == "tool_call":
+            fc = item
+            break
     if not fc:
         return None, None
     name = getattr(fc, "name", None)

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -8,13 +8,13 @@ import codexdispatch.dispatcher as dispatcher
 
 class TestCallOrchestrator(unittest.TestCase):
     def test_uses_openai_stub(self):
-        fc = types.SimpleNamespace(
+        item = types.SimpleNamespace(
+            type="tool_call",
             name="orchestrator_decision",
             arguments=json.dumps({"conclusion": "valid", "summary": "done"}),
         )
-        msg = types.SimpleNamespace(function_call=fc)
-        choice = types.SimpleNamespace(message=msg)
-        mock_response = types.SimpleNamespace(choices=[choice])
+        msg = types.SimpleNamespace(content=[item])
+        mock_response = types.SimpleNamespace(output=[msg])
 
         with mock.patch(
             "codexdispatch.openai_stub.openai_generate_response",


### PR DESCRIPTION
## Summary
- route OpenAI calls through Responses API with web_search tool enabled
- adapt function call parsing for Responses output
- update orchestrator test for new tool_call format

## Testing
- `flake8` *(fails: E501, E741, E125, W391)*
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68905122dba08324a1b850bb7a7b6bfe