### PR TITLE
Allow passing orchestrator env

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -23,8 +23,13 @@ from .utils import collect_files, _invoke_codex, find_codex_bin, load_files
 from .security_audit import run_security_audit
 
 
-def call_orchestrator(prompt: str) -> dict:
+def call_orchestrator(prompt: str, env: dict[str, str] | None = None) -> dict:
     """Return {"inquiry": "..."} or {"conclusion": "valid|invalid", "summary": "..."}."""
+    if env:
+        old_env = os.environ.copy()
+        os.environ.update(env)
+    else:
+        old_env = None
     try:
         from . import openai_stub
 
@@ -77,6 +82,13 @@ def call_orchestrator(prompt: str) -> dict:
                 }
     except Exception as exc:  # pragma: no cover - fallback path
         logging.warning("call_orchestrator falling back to stub: %s", exc)
+    finally:
+        if old_env is not None:
+            for k in env or {}:
+                if k in old_env:
+                    os.environ[k] = old_env[k]
+                else:
+                    os.environ.pop(k, None)
     # This stub randomly concludes or asks for more details to exercise both
     # branches during tests without requiring real API calls.
     if random.random() < 0.3:
@@ -204,7 +216,7 @@ def _run_paramtrace_scan(path: str) -> None:
     print(json.dumps(matches, indent=2))
 
 
-def _run_phase_mode(args) -> None:
+def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> None:
     try:
         with open(args.orchestrator_template, "r", encoding="utf-8") as f:
             orchestrator_template = f.read()
@@ -342,7 +354,7 @@ def _run_phase_mode(args) -> None:
             for idx in range(len(context), args.max_inquiries):
                 prior_ctx = json.dumps(context, indent=2)
                 prompt = f"{orchestrator_template}\n{finding_json}\n{prior_ctx}"
-                result = call_orchestrator(prompt)
+                result = call_orchestrator(prompt, env=orchestrator_env)
                 if "conclusion" in result:
                     final_path = os.path.join(final_dir, rel)
                     os.makedirs(os.path.dirname(final_path), exist_ok=True)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -371,7 +371,7 @@ class PhaseModeIntegration(unittest.TestCase):
                     fh.write("X")
                 captured.append(out)
 
-            def fake_orchestrator(prompt):
+            def fake_orchestrator(prompt, env=None):
                 return {"conclusion": "valid", "summary": "done"}
 
             with unittest.mock.patch.object(sys, "argv", argv), \

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -1,4 +1,5 @@
 import json
+import os
 import types
 import unittest
 from unittest import mock
@@ -28,3 +29,19 @@ class TestCallOrchestrator(unittest.TestCase):
         self.assertEqual(kwargs["model"], "o3")
         self.assertEqual(kwargs["service_tier"], "flex")
         self.assertEqual(kwargs["reasoning_effort"], "high")
+
+    def test_env_is_passed(self):
+        captured = {}
+
+        def fake_generate_response(**kwargs):
+            captured["val"] = os.environ.get("TEST_KEY")
+            return types.SimpleNamespace(output=[])
+
+        with mock.patch(
+            "codexdispatch.openai_stub.openai_generate_response",
+            side_effect=fake_generate_response,
+        ):
+            dispatcher.call_orchestrator("prompt", env={"TEST_KEY": "VAL"})
+
+        self.assertEqual(captured.get("val"), "VAL")
+        self.assertNotIn("TEST_KEY", os.environ)

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -64,7 +64,7 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
             orch_responses = [{"inquiry": "why?"}, {"conclusion": "valid", "summary": "done"}]
 
-            def fake_orchestrator(prompt):
+            def fake_orchestrator(prompt, env=None):
                 return orch_responses.pop(0)
 
             with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
@@ -156,7 +156,7 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 {"conclusion": "invalid", "summary": "oops"},
             ]
 
-            def fake_orchestrator(prompt):
+            def fake_orchestrator(prompt, env=None):
                 return orch_responses.pop(0)
 
             with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
@@ -182,6 +182,57 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 wd_map[os.path.join(phase1_dir, os.path.basename(f1))], workdir
             )
             self.assertEqual(len(captured_cmds), 1)
+
+    def test_orchestrator_env_forwarded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            finding = os.path.join(tmp, "f.json")
+            with open(finding, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({"finding": "x"}))
+            listfile = os.path.join(tmp, "findings.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(finding + "\n")
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--findings-workdir",
+                workdir,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_env: dict[str, str] = {}
+
+            def fake_find_codex_bin(path):
+                return "codex"
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                pass
+
+            def fake_orchestrator(prompt, env=None):
+                captured_env.update(env or {})
+                return {"conclusion": "valid", "summary": "done"}
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
+                mock.patch("codexdispatch.dispatcher._invoke_codex", fake_invoke), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", fake_orchestrator):
+                dispatcher._run_phase_mode(args, orchestrator_env={"FOO": "BAR"})
+
+            self.assertEqual(captured_env, {"FOO": "BAR"})
 
     def test_cache_resume(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -228,7 +279,7 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
             orch_responses = [{"inquiry": "why?"}]
 
-            def first_orchestrator(prompt):
+            def first_orchestrator(prompt, env=None):
                 if orch_responses:
                     return orch_responses.pop(0)
                 raise IndexError
@@ -252,7 +303,7 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
             orch_responses2 = [{"conclusion": "valid", "summary": "done"}]
 
-            def second_orchestrator(prompt):
+            def second_orchestrator(prompt, env=None):
                 return orch_responses2.pop(0)
 
             captured_cmds2: list[list[str]] = []


### PR DESCRIPTION
## Summary
- allow supplying env vars when calling the orchestrator and propagate them from phase mode
- expand tests for orchestrator env handling

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890574422488324a5f8fb929860837a