### PR TITLE
Handle JSON parsing errors in phase mode

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -23,6 +23,19 @@ from .utils import collect_files, _invoke_codex, find_codex_bin, load_files
 from .security_audit import run_security_audit
 
 
+def _strip_backticks(text: str) -> str:
+    """Remove surrounding markdown code fences from ``text`` if present."""
+    stripped = text.strip()
+    if stripped.startswith("```") and stripped.endswith("```"):
+        lines = stripped.splitlines()
+        if lines:
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        return "\n".join(lines)
+    return text
+
+
 def call_orchestrator(prompt: str, env: dict[str, str] | None = None) -> dict:
     """Return {"inquiry": "..."} or {"conclusion": "valid|invalid", "summary": "..."}."""
     if env:
@@ -234,6 +247,7 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
     final_dir = os.path.join(args.output_dir, "final")
     os.makedirs(phase1_dir, exist_ok=True)
     os.makedirs(final_dir, exist_ok=True)
+    error_log_path = os.path.join(phase1_dir, "parse_errors.log")
     cache_dir = os.path.join(os.path.dirname(os.path.abspath(args.output_dir)), "cache")
     os.makedirs(cache_dir, exist_ok=True)
     workdirs_path = Path(cache_dir) / "workdirs.json"
@@ -340,6 +354,26 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
             except OSError as exc:
                 logging.error("PhaseMode: failed reading %s: %s", finding_path, exc)
                 continue
+
+            try:
+                json.loads(finding_json)
+            except json.JSONDecodeError as exc:
+                cleaned = _strip_backticks(finding_json)
+                if cleaned != finding_json:
+                    try:
+                        json.loads(cleaned)
+                    except json.JSONDecodeError as exc2:
+                        with open(error_log_path, "a", encoding="utf-8") as ef:
+                            ef.write(f"{rel}: {exc2}\n")
+                        continue
+                    with open(finding_path, "w", encoding="utf-8") as fh:
+                        fh.write(cleaned)
+                    finding_json = cleaned
+                else:
+                    with open(error_log_path, "a", encoding="utf-8") as ef:
+                        ef.write(f"{rel}: {exc}\n")
+                    continue
+
             cache_entry = {"context": [], "status": "open"}
             if os.path.exists(cache_path):
                 try:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -368,7 +368,7 @@ class PhaseModeIntegration(unittest.TestCase):
                 out = cmd[cmd.index("--output-last-message") + 1]
                 os.makedirs(os.path.dirname(out), exist_ok=True)
                 with open(out, "w", encoding="utf-8") as fh:
-                    fh.write("X")
+                    fh.write(json.dumps({"finding": "x"}))
                 captured.append(out)
 
             def fake_orchestrator(prompt, env=None):

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -234,6 +234,107 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
             self.assertEqual(captured_env, {"FOO": "BAR"})
 
+    def test_backtick_wrapped_findings_cleaned(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            finding = os.path.join(tmp, "f.json")
+            with open(finding, "w", encoding="utf-8") as fh:
+                fh.write('````\n{"finding": "x"}\n````'.replace("```" + "`", "```"))
+            listfile = os.path.join(tmp, "findings.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(finding + "\n")
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--findings-workdir",
+                workdir,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            def fake_find_codex_bin(path):
+                return "codex"
+
+            def fake_orchestrator(prompt, env=None):
+                return {"conclusion": "valid", "summary": "done"}
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", fake_orchestrator):
+                dispatcher._run_phase_mode(args)
+
+            phase1_dir = os.path.join(outdir, "phase_1")
+            phase1_path = os.path.join(phase1_dir, os.path.basename(finding))
+            with open(phase1_path, "r", encoding="utf-8") as fh:
+                data = fh.read()
+            self.assertEqual(data, json.dumps({"finding": "x"}))
+            self.assertFalse(os.path.exists(os.path.join(phase1_dir, "parse_errors.log")))
+
+    def test_unparsable_findings_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            finding = os.path.join(tmp, "f.json")
+            with open(finding, "w", encoding="utf-8") as fh:
+                fh.write("{not json")
+            listfile = os.path.join(tmp, "findings.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(finding + "\n")
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--findings-workdir",
+                workdir,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            def fake_find_codex_bin(path):
+                return "codex"
+
+            orch_mock = mock.Mock()
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", orch_mock):
+                dispatcher._run_phase_mode(args)
+
+            orch_mock.assert_not_called()
+            phase1_dir = os.path.join(outdir, "phase_1")
+            final_dir = os.path.join(outdir, "final")
+            rel = os.path.basename(finding)
+            self.assertFalse(os.path.exists(os.path.join(final_dir, rel)))
+            err_log = os.path.join(phase1_dir, "parse_errors.log")
+            self.assertTrue(os.path.exists(err_log))
+            with open(err_log, "r", encoding="utf-8") as ef:
+                text = ef.read()
+            self.assertIn(rel, text)
+
     def test_cache_resume(self):
         with tempfile.TemporaryDirectory() as tmp:
             finding = os.path.join(tmp, "f.json")


### PR DESCRIPTION
## Summary
- clean markdown code fences from phase-one findings before parsing
- log unfixable phase-one findings and skip them in later phases
- test backtick cleanup and skip behavior; adjust integration to use valid JSON

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905bed6fd48324a5f0528a15c4b23c