### PR TITLE
feat: filter phase-mode vulns by severity

### DIFF
--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -191,6 +191,13 @@ def parse_args() -> argparse.Namespace:
         default=3,
         help="cap on orchestrator and Codex iterations per finding",
     )
+    parser.add_argument(
+        "--min-severity",
+        dest="min_severity",
+        choices=["low", "medium", "high", "critical"],
+        default=None,
+        help="minimum severity required for a vulnerability to be processed by the orchestrator in phase mode",
+    )
     args = parser.parse_args()
     if args.scan_paramtrace:
         return args
@@ -226,6 +233,8 @@ def parse_args() -> argparse.Namespace:
         if args.output_dir is None or args.workers is None:
             parser.error("--output-dir and --workers are required")
         return args
+    if args.min_severity:
+        parser.error("--min-severity requires --phase-mode")
     if args.findings_list or args.findings_workdir:
         parser.error("--findings-list and --findings-workdir require --phase-mode")
     if args.template is None:

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -356,12 +356,12 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
                 continue
 
             try:
-                json.loads(finding_json)
+                finding_obj = json.loads(finding_json)
             except json.JSONDecodeError as exc:
                 cleaned = _strip_backticks(finding_json)
                 if cleaned != finding_json:
                     try:
-                        json.loads(cleaned)
+                        finding_obj = json.loads(cleaned)
                     except json.JSONDecodeError as exc2:
                         with open(error_log_path, "a", encoding="utf-8") as ef:
                             ef.write(f"{rel}: {exc2}\n")
@@ -372,6 +372,12 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
                 else:
                     with open(error_log_path, "a", encoding="utf-8") as ef:
                         ef.write(f"{rel}: {exc}\n")
+                    continue
+
+            if args.min_severity:
+                sev = finding_obj.get("severity")
+                ranks = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+                if sev is None or ranks.get(str(sev).lower(), -1) < ranks[args.min_severity]:
                     continue
 
             cache_entry = {"context": [], "status": "open"}

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -234,6 +234,66 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
             self.assertEqual(captured_env, {"FOO": "BAR"})
 
+    def test_min_severity_filter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            high = os.path.join(tmp, "high.json")
+            low = os.path.join(tmp, "low.json")
+            with open(high, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({"finding": "a", "severity": "high"}))
+            with open(low, "w", encoding="utf-8") as fh:
+                fh.write(json.dumps({"finding": "b", "severity": "low"}))
+            listfile = os.path.join(tmp, "findings.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(high + "\n")
+                fh.write(low + "\n")
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--findings-workdir",
+                workdir,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+                "--min-severity",
+                "medium",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            def fake_find_codex_bin(path):
+                return "codex"
+
+            orch_calls: list[str] = []
+
+            def fake_orchestrator(prompt, env=None):
+                orch_calls.append(prompt)
+                return {"conclusion": "valid", "summary": "ok"}
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", fake_find_codex_bin), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", fake_orchestrator):
+                dispatcher._run_phase_mode(args)
+
+            self.assertEqual(len(orch_calls), 1)
+            final_dir = os.path.join(outdir, "final")
+            self.assertTrue(
+                os.path.exists(os.path.join(final_dir, os.path.basename(high)))
+            )
+            self.assertFalse(
+                os.path.exists(os.path.join(final_dir, os.path.basename(low)))
+            )
+
     def test_backtick_wrapped_findings_cleaned(self):
         with tempfile.TemporaryDirectory() as tmp:
             finding = os.path.join(tmp, "f.json")


### PR DESCRIPTION
## Summary
- add `--min-severity` CLI option for phase mode
- skip findings below severity threshold before invoking orchestrator
- test that low-severity findings are ignored

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68905f2c8ef883249eab2b0516244a78