### PR TITLE
Add name to Responses API tools

### DIFF
--- a/codexdispatch/openai_stub.py
+++ b/codexdispatch/openai_stub.py
@@ -47,9 +47,12 @@ def openai_generate_response(
     if client is None:
         raise RuntimeError("OpenAI client is not configured")
 
-    tools: List[Dict[str, Any]] = [{"type": "web_search"}]
+    tools: List[Dict[str, Any]] = [{"type": "web_search", "name": "web_search"}]
     if functions:
-        tools.extend({"type": "function", "function": f} for f in functions)
+        tools.extend(
+            {"type": "function", "name": f["name"], "function": f}
+            for f in functions
+        )
 
     params: Dict[str, Any] = {
         "model": model,

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -8,6 +8,7 @@ from unittest import mock
 import openai
 
 import codexdispatch.dispatcher as dispatcher
+import codexdispatch.openai_stub as openai_stub
 
 
 class TestCallOrchestrator(unittest.TestCase):
@@ -80,3 +81,30 @@ class TestCallOrchestrator(unittest.TestCase):
         self.assertEqual(result, {"inquiry": "more info"})
         self.assertEqual(mock_gen.call_count, 2)
         self.assertGreaterEqual(elapsed, 0.01)
+
+
+class TestGenerateResponse(unittest.TestCase):
+    def test_tools_payload_includes_name(self):
+        captured = {}
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                captured["tools"] = kwargs.get("tools", [])
+                return types.SimpleNamespace(output=[])
+
+        fake_client = types.SimpleNamespace(responses=FakeResponses())
+
+        with mock.patch(
+            "codexdispatch.openai_stub.openai_configure_api",
+            return_value=fake_client,
+        ):
+            messages = [{"role": "user", "content": "hi"}]
+            funcs = [{"name": "helper", "parameters": {}}]
+            openai_stub.openai_generate_response(
+                messages=messages, functions=funcs
+            )
+
+        tools = captured.get("tools", [])
+        self.assertTrue(all("name" in t for t in tools))
+        self.assertEqual(tools[0]["name"], "web_search")
+        self.assertEqual(tools[1]["name"], "helper")


### PR DESCRIPTION
## Summary
- ensure Responses API tools payload includes a `name` for web_search and custom functions
- cover tool payload structure with a unit test

## Testing
- `PYTHONPATH=. pytest tests/test_openai_stub.py::TestGenerateResponse::test_tools_payload_includes_name`

------
https://chatgpt.com/codex/tasks/task_e_689068802cd88324a0073ae38b4374d6