### PR TITLE
fix: update tools payload schema

### DIFF
--- a/codexdispatch/openai_stub.py
+++ b/codexdispatch/openai_stub.py
@@ -47,11 +47,10 @@ def openai_generate_response(
     if client is None:
         raise RuntimeError("OpenAI client is not configured")
 
-    tools: List[Dict[str, Any]] = [{"type": "web_search", "name": "web_search"}]
+    tools: List[Dict[str, Any]] = [{"type": "web_search"}]
     if functions:
         tools.extend(
-            {"type": "function", "name": f["name"], "function": f}
-            for f in functions
+            {"type": "function", "function": f} for f in functions
         )
 
     params: Dict[str, Any] = {

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -84,7 +84,7 @@ class TestCallOrchestrator(unittest.TestCase):
 
 
 class TestGenerateResponse(unittest.TestCase):
-    def test_tools_payload_includes_name(self):
+    def test_tools_payload_schema(self):
         captured = {}
 
         class FakeResponses:
@@ -105,6 +105,7 @@ class TestGenerateResponse(unittest.TestCase):
             )
 
         tools = captured.get("tools", [])
-        self.assertTrue(all("name" in t for t in tools))
-        self.assertEqual(tools[0]["name"], "web_search")
-        self.assertEqual(tools[1]["name"], "helper")
+        self.assertEqual(tools[0], {"type": "web_search"})
+        self.assertEqual(tools[1]["type"], "function")
+        self.assertEqual(tools[1]["function"]["name"], "helper")
+        self.assertNotIn("name", tools[1])


### PR DESCRIPTION
## Summary
- remove name from built-in `web_search` tool
- nest function definitions directly under `function` tool entries
- update tests for new tool schema

## Testing
- `PYTHONPATH=. pytest -q`
- `flake8` *(fails: line too long, unused variables, ambiguous names, indentation, blank line)*

------
https://chatgpt.com/codex/tasks/task_e_689069f3f0788324a19e32d5114c4425