### PR TITLE
Fix parsing of Responses API tool calls

### DIFF
--- a/codexdispatch/openai_stub.py
+++ b/codexdispatch/openai_stub.py
@@ -69,22 +69,42 @@ def openai_generate_response(
 
 
 def openai_parse_function_call(response: Any) -> Tuple[Optional[str], Any]:
-    """Extract function call data from a Responses API result."""
-    output = getattr(response, "output", None)
-    msg = output[0] if output else None
-    content = getattr(msg, "content", []) if msg else []
+    """Extract function call data from a Responses API result.
+
+    The Responses API evolved its schema in April 2025.  Newer models return
+    ``ResponseFunctionToolCall`` objects directly in ``response.output``
+    whereas older models nested the call inside the first message's
+    ``content`` list.  This helper now supports both layouts for
+    backward-compatibility.
+    """
+
     fc = None
-    for item in content:
-        if getattr(item, "type", None) == "tool_call":
+
+    # Newer schema: function/tool call objects are top-level ``output`` items.
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) in {"function_call", "tool_call"}:
             fc = item
             break
+
+    # Legacy schema: tool call lives inside ``content`` of the first message.
+    if not fc:
+        output = getattr(response, "output", None)
+        msg = output[0] if output else None
+        content = getattr(msg, "content", []) if msg else []
+        for item in content:
+            if getattr(item, "type", None) == "tool_call":
+                fc = item
+                break
+
     if not fc:
         return None, None
+
     name = getattr(fc, "name", None)
     args_str = getattr(fc, "arguments", "") or "{}"
     try:
         data = json.loads(args_str)
     except json.JSONDecodeError:
         data = {}
+
     logging.info("Function call %s with %s", name, data)
     return name, data

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -14,12 +14,11 @@ import codexdispatch.openai_stub as openai_stub
 class TestCallOrchestrator(unittest.TestCase):
     def test_uses_openai_stub(self):
         item = types.SimpleNamespace(
-            type="tool_call",
+            type="function_call",
             name="orchestrator_decision",
             arguments=json.dumps({"conclusion": "valid", "summary": "done"}),
         )
-        msg = types.SimpleNamespace(content=[item])
-        mock_response = types.SimpleNamespace(output=[msg])
+        mock_response = types.SimpleNamespace(output=[item])
 
         with mock.patch(
             "codexdispatch.openai_stub.openai_generate_response",
@@ -64,12 +63,11 @@ class TestCallOrchestrator(unittest.TestCase):
 
     def test_retry_recovers_after_failure(self):
         item = types.SimpleNamespace(
-            type="tool_call",
+            type="function_call",
             name="orchestrator_decision",
             arguments=json.dumps({"inquiry": "more info"}),
         )
-        msg = types.SimpleNamespace(content=[item])
-        mock_response = types.SimpleNamespace(output=[msg])
+        mock_response = types.SimpleNamespace(output=[item])
         side_effects = [openai.OpenAIError("fail"), mock_response]
         with mock.patch.object(dispatcher, "BACKOFF_BASE", 0.01), mock.patch(
             "codexdispatch.openai_stub.openai_generate_response",
@@ -110,3 +108,32 @@ class TestGenerateResponse(unittest.TestCase):
         self.assertEqual(tools[1]["name"], "helper")
         self.assertEqual(tools[1]["parameters"], {})
         self.assertNotIn("function", tools[1])
+
+
+class TestParseFunctionCall(unittest.TestCase):
+    def test_parses_top_level_function_call(self):
+        item = types.SimpleNamespace(
+            type="function_call",
+            name="orchestrator_decision",
+            arguments=json.dumps({"inquiry": "info"}),
+        )
+        response = types.SimpleNamespace(output=[item])
+
+        name, data = openai_stub.openai_parse_function_call(response)
+
+        self.assertEqual(name, "orchestrator_decision")
+        self.assertEqual(data, {"inquiry": "info"})
+
+    def test_parses_legacy_tool_call(self):
+        item = types.SimpleNamespace(
+            type="tool_call",
+            name="orchestrator_decision",
+            arguments=json.dumps({"conclusion": "valid"}),
+        )
+        msg = types.SimpleNamespace(content=[item])
+        response = types.SimpleNamespace(output=[msg])
+
+        name, data = openai_stub.openai_parse_function_call(response)
+
+        self.assertEqual(name, "orchestrator_decision")
+        self.assertEqual(data, {"conclusion": "valid"})


### PR DESCRIPTION
## Summary
- handle top-level `ResponseFunctionToolCall` items from the 2025 Responses API
- keep backwards compatibility with legacy `content[]` tool calls
- add tests for new and legacy function-call structures

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68906cf076a08324ad72d675e46993e5