### PR TITLE
feat: derive findings workdir from file path

### DIFF
--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -149,12 +149,6 @@ def parse_args() -> argparse.Namespace:
         help="mapping filename for multi-pass mode",
     )
     parser.add_argument(
-        "--findings-workdir",
-        dest="findings_workdir",
-        default=None,
-        help="working directory associated with entries from --findings-list",
-    )
-    parser.add_argument(
         "--relative-dir",
         dest="relative_dir",
         default=None,
@@ -203,8 +197,6 @@ def parse_args() -> argparse.Namespace:
         return args
     if args.phase_mode:
         if args.findings_list:
-            if not args.findings_workdir:
-                parser.error("--findings-workdir is required with --findings-list")
             if any(
                 [
                     args.data_dir,
@@ -221,8 +213,6 @@ def parse_args() -> argparse.Namespace:
                 parser.error("--orchestrator-template is required with --findings-list")
             if args.output_dir is None or args.workers is None:
                 parser.error("--output-dir and --workers are required")
-            if not os.path.isdir(args.findings_workdir):
-                parser.error("--findings-workdir must be an existing directory")
             return args
         if not args.audit_template or not args.orchestrator_template:
             parser.error("--audit-template and --orchestrator-template are required with --phase-mode")
@@ -235,8 +225,8 @@ def parse_args() -> argparse.Namespace:
         return args
     if args.min_severity:
         parser.error("--min-severity requires --phase-mode")
-    if args.findings_list or args.findings_workdir:
-        parser.error("--findings-list and --findings-workdir require --phase-mode")
+    if args.findings_list:
+        parser.error("--findings-list requires --phase-mode")
     if args.template is None:
         parser.error("template is required")
     if not any([args.data_dir, args.tree_dirs, args.file_list, args.findings_json]):

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -16,7 +16,6 @@ import shutil
 import inspect
 import time
 import openai
-from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional
 
@@ -273,16 +272,6 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
     error_log_path = os.path.join(phase1_dir, "parse_errors.log")
     cache_dir = os.path.join(os.path.dirname(os.path.abspath(args.output_dir)), "cache")
     os.makedirs(cache_dir, exist_ok=True)
-    workdirs_path = Path(cache_dir) / "workdirs.json"
-    if workdirs_path.exists():
-        try:
-            with open(workdirs_path, "r", encoding="utf-8") as wf:
-                workdir_map: Dict[str, str] = json.load(wf)
-        except (OSError, json.JSONDecodeError):
-            workdir_map = {}
-    else:
-        workdir_map = {}
-
     if args.findings_list:
         try:
             with open(args.findings_list, "r", encoding="utf-8") as fh:
@@ -307,9 +296,6 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
             except OSError as exc:
                 logging.error("PhaseMode: failed copying %s: %s", src, exc)
                 continue
-            workdir_map[dest] = args.findings_workdir
-        with open(workdirs_path, "w", encoding="utf-8") as wf:
-            json.dump(workdir_map, wf)
     else:
         if args.tree_dirs:
             inputs = collect_files(args.tree_dirs, recursive=args.recursive)
@@ -360,9 +346,6 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
                 logging.error("Codex exit %s on %s\n%s", cpe.returncode, path, stderr)
             except Exception as exc:
                 logging.error("Failed processing %s: %s", path, exc)
-            workdir_map[out_path] = os.path.dirname(path)
-            with open(workdirs_path, "w", encoding="utf-8") as wf:
-                json.dump(workdir_map, wf)
 
     # Phase 2..N – orchestrator loop
     for dirpath, _, filenames in os.walk(phase1_dir):
@@ -402,6 +385,11 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
                 ranks = {"low": 0, "medium": 1, "high": 2, "critical": 3}
                 if sev is None or ranks.get(str(sev).lower(), -1) < ranks[args.min_severity]:
                     continue
+
+            file_path = finding_obj.get("file_path")
+            default_work_dir = (
+                os.path.dirname(os.path.abspath(file_path)) if file_path else args.work_dir
+            )
 
             cache_entry = {"context": [], "status": "open"}
             if os.path.exists(cache_path):
@@ -443,7 +431,7 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
                     "--dangerously-bypass-approvals-and-sandbox",
                     "--skip-git-repo-check",
                 ]
-                work_dir = workdir_map.get(finding_path, args.work_dir)
+                work_dir = default_work_dir
                 if work_dir:
                     cmd.extend(["-C", work_dir])
                 try:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -165,23 +165,6 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(args.file_list, "files.txt")
         self.assertEqual(args.max_inquiries, 3)
 
-    def test_findings_list_requires_workdir(self):
-        argv = [
-            "dispatch.py",
-            "--phase-mode",
-            "--orchestrator-template",
-            "orch.txt",
-            "--findings-list",
-            "list.txt",
-            "-o",
-            "out",
-            "-j",
-            "1",
-        ]
-        with unittest.mock.patch.object(sys, "argv", argv):
-            with self.assertRaises(SystemExit):
-                dispatch.parse_args()
-
     def test_findings_list_conflicts(self):
         argv = [
             "dispatch.py",
@@ -190,8 +173,6 @@ class TestParseArgs(unittest.TestCase):
             "orch.txt",
             "--findings-list",
             "list.txt",
-            "--findings-workdir",
-            "wd",
             "--tree-dirs",
             "src",
             "-o",
@@ -204,25 +185,21 @@ class TestParseArgs(unittest.TestCase):
                 dispatch.parse_args()
 
     def test_parse_findings_resume(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            argv = [
-                "dispatch.py",
-                "--phase-mode",
-                "--orchestrator-template",
-                "orch.txt",
-                "--findings-list",
-                "list.txt",
-                "--findings-workdir",
-                tmp,
-                "-o",
-                "out",
-                "-j",
-                "1",
-            ]
-            with unittest.mock.patch.object(sys, "argv", argv):
-                args = dispatch.parse_args()
-            self.assertEqual(args.findings_list, "list.txt")
-            self.assertEqual(args.findings_workdir, tmp)
+        argv = [
+            "dispatch.py",
+            "--phase-mode",
+            "--orchestrator-template",
+            "orch.txt",
+            "--findings-list",
+            "list.txt",
+            "-o",
+            "out",
+            "-j",
+            "1",
+        ]
+        with unittest.mock.patch.object(sys, "argv", argv):
+            args = dispatch.parse_args()
+        self.assertEqual(args.findings_list, "list.txt")
 
 
 class TestWorkDirSelection(unittest.TestCase):

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -47,7 +47,7 @@ class TestPhaseModeWorkflow(unittest.TestCase):
             def fake_find_codex_bin(path):
                 return "codex"
 
-            phase1_output = '{"finding": "x"}'
+            phase1_output = json.dumps({"finding": "x", "file_path": src})
             inquiry_output = "resp"
 
             captured_cmds: list[list[str]] = []
@@ -82,15 +82,12 @@ class TestPhaseModeWorkflow(unittest.TestCase):
             cache_dir = os.path.join(tmp, "cache")
             self.assertTrue(os.path.isdir(cache_dir))
             cache_files = os.listdir(cache_dir)
-            self.assertIn("workdirs.json", cache_files)
-            hash_file = [f for f in cache_files if f != "workdirs.json"][0]
+            self.assertEqual(len(cache_files), 1)
+            hash_file = cache_files[0]
             with open(os.path.join(cache_dir, hash_file), "r", encoding="utf-8") as cf:
                 data = json.load(cf)
             self.assertEqual(data["status"], "concluded")
             self.assertEqual(len(data["context"]), 1)
-            with open(os.path.join(cache_dir, "workdirs.json"), "r", encoding="utf-8") as wf:
-                wd_map = json.load(wf)
-            self.assertEqual(wd_map[phase1_path], os.path.dirname(src))
             phase2_meta = phase2_path + ".meta"
             self.assertTrue(os.path.exists(phase2_meta))
             with open(phase2_meta, "r", encoding="utf-8") as mf:
@@ -104,11 +101,17 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
     def test_presupplied_findings_run(self):
         with tempfile.TemporaryDirectory() as tmp:
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
             f1 = os.path.join(tmp, "f1.json")
             f2 = os.path.join(tmp, "f2.json")
             for path, val in ((f1, "a"), (f2, "b")):
                 with open(path, "w", encoding="utf-8") as fh:
-                    fh.write(json.dumps({"finding": val}))
+                    fh.write(
+                        json.dumps(
+                            {"finding": val, "file_path": os.path.join(workdir, val + ".rb")}
+                        )
+                    )
             listfile = os.path.join(tmp, "findings.txt")
             with open(listfile, "w", encoding="utf-8") as fh:
                 fh.write(f1 + "\n")
@@ -120,8 +123,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 fh.write("orch")
             outdir = os.path.join(tmp, "out")
             os.mkdir(outdir)
-            workdir = os.path.join(tmp, "repo")
-            os.mkdir(workdir)
             argv = [
                 "dispatch.py",
                 "--phase-mode",
@@ -129,8 +130,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 orch,
                 "--findings-list",
                 listfile,
-                "--findings-workdir",
-                workdir,
                 "-o",
                 outdir,
                 "-j",
@@ -175,19 +174,22 @@ class TestPhaseModeWorkflow(unittest.TestCase):
             with open(phase2_meta, "r", encoding="utf-8") as mf:
                 meta = json.load(mf)
             self.assertEqual(meta["response"], "resp")
-            cache_dir = os.path.join(tmp, "cache")
-            with open(os.path.join(cache_dir, "workdirs.json"), "r", encoding="utf-8") as wf:
-                wd_map = json.load(wf)
-            self.assertEqual(
-                wd_map[os.path.join(phase1_dir, os.path.basename(f1))], workdir
-            )
             self.assertEqual(len(captured_cmds), 1)
+            cmd = captured_cmds[0]
+            self.assertIn("-C", cmd)
+            self.assertEqual(cmd[cmd.index("-C") + 1], workdir)
 
     def test_orchestrator_env_forwarded(self):
         with tempfile.TemporaryDirectory() as tmp:
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
             finding = os.path.join(tmp, "f.json")
             with open(finding, "w", encoding="utf-8") as fh:
-                fh.write(json.dumps({"finding": "x"}))
+                fh.write(
+                    json.dumps(
+                        {"finding": "x", "file_path": os.path.join(workdir, "f.rb")}
+                    )
+                )
             listfile = os.path.join(tmp, "findings.txt")
             with open(listfile, "w", encoding="utf-8") as fh:
                 fh.write(finding + "\n")
@@ -196,8 +198,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 fh.write("orch")
             outdir = os.path.join(tmp, "out")
             os.mkdir(outdir)
-            workdir = os.path.join(tmp, "repo")
-            os.mkdir(workdir)
             argv = [
                 "dispatch.py",
                 "--phase-mode",
@@ -205,8 +205,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 orch,
                 "--findings-list",
                 listfile,
-                "--findings-workdir",
-                workdir,
                 "-o",
                 outdir,
                 "-j",
@@ -236,12 +234,30 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
     def test_min_severity_filter(self):
         with tempfile.TemporaryDirectory() as tmp:
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
             high = os.path.join(tmp, "high.json")
             low = os.path.join(tmp, "low.json")
             with open(high, "w", encoding="utf-8") as fh:
-                fh.write(json.dumps({"finding": "a", "severity": "high"}))
+                fh.write(
+                    json.dumps(
+                        {
+                            "finding": "a",
+                            "severity": "high",
+                            "file_path": os.path.join(workdir, "h.rb"),
+                        }
+                    )
+                )
             with open(low, "w", encoding="utf-8") as fh:
-                fh.write(json.dumps({"finding": "b", "severity": "low"}))
+                fh.write(
+                    json.dumps(
+                        {
+                            "finding": "b",
+                            "severity": "low",
+                            "file_path": os.path.join(workdir, "l.rb"),
+                        }
+                    )
+                )
             listfile = os.path.join(tmp, "findings.txt")
             with open(listfile, "w", encoding="utf-8") as fh:
                 fh.write(high + "\n")
@@ -251,8 +267,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 fh.write("orch")
             outdir = os.path.join(tmp, "out")
             os.mkdir(outdir)
-            workdir = os.path.join(tmp, "repo")
-            os.mkdir(workdir)
             argv = [
                 "dispatch.py",
                 "--phase-mode",
@@ -260,8 +274,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 orch,
                 "--findings-list",
                 listfile,
-                "--findings-workdir",
-                workdir,
                 "-o",
                 outdir,
                 "-j",
@@ -296,9 +308,16 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
     def test_backtick_wrapped_findings_cleaned(self):
         with tempfile.TemporaryDirectory() as tmp:
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
             finding = os.path.join(tmp, "f.json")
+            wrapped = (
+                '````\n{"finding": "x", "file_path": "'
+                + os.path.join(workdir, "f.rb")
+                + '"}\n````'
+            ).replace("```" + "`", "```")
             with open(finding, "w", encoding="utf-8") as fh:
-                fh.write('````\n{"finding": "x"}\n````'.replace("```" + "`", "```"))
+                fh.write(wrapped)
             listfile = os.path.join(tmp, "findings.txt")
             with open(listfile, "w", encoding="utf-8") as fh:
                 fh.write(finding + "\n")
@@ -307,8 +326,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 fh.write("orch")
             outdir = os.path.join(tmp, "out")
             os.mkdir(outdir)
-            workdir = os.path.join(tmp, "repo")
-            os.mkdir(workdir)
             argv = [
                 "dispatch.py",
                 "--phase-mode",
@@ -316,8 +333,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 orch,
                 "--findings-list",
                 listfile,
-                "--findings-workdir",
-                workdir,
                 "-o",
                 outdir,
                 "-j",
@@ -340,7 +355,10 @@ class TestPhaseModeWorkflow(unittest.TestCase):
             phase1_path = os.path.join(phase1_dir, os.path.basename(finding))
             with open(phase1_path, "r", encoding="utf-8") as fh:
                 data = fh.read()
-            self.assertEqual(data, json.dumps({"finding": "x"}))
+            self.assertEqual(
+                data,
+                json.dumps({"finding": "x", "file_path": os.path.join(workdir, "f.rb")}),
+            )
             self.assertFalse(os.path.exists(os.path.join(phase1_dir, "parse_errors.log")))
 
     def test_unparsable_findings_skipped(self):
@@ -356,8 +374,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 fh.write("orch")
             outdir = os.path.join(tmp, "out")
             os.mkdir(outdir)
-            workdir = os.path.join(tmp, "repo")
-            os.mkdir(workdir)
             argv = [
                 "dispatch.py",
                 "--phase-mode",
@@ -365,8 +381,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 orch,
                 "--findings-list",
                 listfile,
-                "--findings-workdir",
-                workdir,
                 "-o",
                 outdir,
                 "-j",
@@ -397,9 +411,15 @@ class TestPhaseModeWorkflow(unittest.TestCase):
 
     def test_cache_resume(self):
         with tempfile.TemporaryDirectory() as tmp:
+            workdir = os.path.join(tmp, "repo")
+            os.mkdir(workdir)
             finding = os.path.join(tmp, "f.json")
             with open(finding, "w", encoding="utf-8") as fh:
-                fh.write(json.dumps({"finding": "x"}))
+                fh.write(
+                    json.dumps(
+                        {"finding": "x", "file_path": os.path.join(workdir, "f.rb")}
+                    )
+                )
             listfile = os.path.join(tmp, "findings.txt")
             with open(listfile, "w", encoding="utf-8") as fh:
                 fh.write(finding + "\n")
@@ -408,8 +428,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 fh.write("orch")
             outdir = os.path.join(tmp, "out")
             os.mkdir(outdir)
-            workdir = os.path.join(tmp, "repo")
-            os.mkdir(workdir)
             argv = [
                 "dispatch.py",
                 "--phase-mode",
@@ -417,8 +435,6 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 orch,
                 "--findings-list",
                 listfile,
-                "--findings-workdir",
-                workdir,
                 "-o",
                 outdir,
                 "-j",


### PR DESCRIPTION
## Summary
- drop `--findings-workdir` flag and compute workdir from each finding's `file_path`
- adjust phase mode to derive per-finding directories on the fly
- update tests for new behavior

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906e5c02e4832485a65da991850ba8