### PR TITLE
Add phase root directory option for phase mode file resolution

### DIFF
--- a/codexdispatch/args.py
+++ b/codexdispatch/args.py
@@ -192,6 +192,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="minimum severity required for a vulnerability to be processed by the orchestrator in phase mode",
     )
+    parser.add_argument(
+        "--phase-root",
+        dest="phase_root",
+        default=None,
+        help="top-level directory to resolve vulnerability file paths in phase mode",
+    )
     args = parser.parse_args()
     if args.scan_paramtrace:
         return args

--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -445,12 +445,23 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
             continue
         context = cache_entry.get("context", [])
         source = ""
-        work_dir = os.path.dirname(os.path.abspath(file_path))
+        resolved_path = file_path
+        work_dir = os.path.dirname(os.path.abspath(resolved_path))
         try:
-            with open(file_path, "r", encoding="utf-8") as sf:
+            with open(resolved_path, "r", encoding="utf-8") as sf:
                 source = sf.read()
         except OSError:
-            logging.warning("PhaseMode: unable to read %s", file_path)
+            if args.phase_root:
+                alt_path = os.path.join(args.phase_root, file_path)
+                try:
+                    with open(alt_path, "r", encoding="utf-8") as sf:
+                        source = sf.read()
+                        resolved_path = alt_path
+                        work_dir = os.path.dirname(os.path.abspath(resolved_path))
+                except OSError:
+                    logging.warning("PhaseMode: unable to read %s", file_path)
+            else:
+                logging.warning("PhaseMode: unable to read %s", file_path)
 
         finding_json = json.dumps(finding_obj, indent=2)
         concluded = False

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -105,6 +105,79 @@ class TestPhaseModeWorkflow(unittest.TestCase):
             self.assertIn("source", prompts[0])
 
 
+    def test_phase_mode_phase_root_resolution(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = os.path.join(tmp, "repo")
+            os.makedirs(os.path.join(repo, "pkg"), exist_ok=True)
+            src_rel = os.path.join("pkg", "src.txt")
+            src = os.path.join(repo, src_rel)
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("hello")
+
+            findings = {
+                "vulnerabilities": [
+                    {"id": "v1", "file_path": src_rel, "severity": "low"}
+                ]
+            }
+            findings_path = os.path.join(tmp, "findings.json")
+            with open(findings_path, "w", encoding="utf-8") as fh:
+                json.dump(findings, fh)
+
+            listfile = os.path.join(tmp, "list.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(findings_path + "\n")
+
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--phase-root",
+                repo,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_cmds: list[list[str]] = []
+            prompts: list[str] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [{"inquiry": "why"}, {"conclusion": "valid"}]
+
+            def fake_orchestrator(prompt, env=None):
+                prompts.append(prompt)
+                return orch_responses.pop(0)
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", return_value="codex"), \
+                mock.patch("codexdispatch.dispatcher._invoke_codex", side_effect=fake_invoke), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", side_effect=fake_orchestrator):
+                dispatcher._run_phase_mode(args)
+
+            self.assertIn("hello", prompts[0])
+            self.assertEqual(
+                captured_cmds[0][captured_cmds[0].index("-C") + 1],
+                os.path.join(repo, "pkg"),
+            )
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Summary
- allow specifying a phase root directory for file path resolution
- resolve vulnerability file paths relative to the phase root if opening fails
- test phase root resolution in phase mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907cf20b108324a00eade13efb9796