### PR TITLE
Handle unresolved file paths in phase mode by checking `ee` directory

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -459,7 +459,14 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
                         resolved_path = alt_path
                         work_dir = os.path.dirname(os.path.abspath(resolved_path))
                 except OSError:
-                    logging.warning("PhaseMode: unable to read %s", file_path)
+                    ee_alt_path = os.path.join(args.phase_root, "ee", file_path)
+                    try:
+                        with open(ee_alt_path, "r", encoding="utf-8") as sf:
+                            source = sf.read()
+                            resolved_path = ee_alt_path
+                            work_dir = os.path.dirname(os.path.abspath(resolved_path))
+                    except OSError:
+                        logging.warning("PhaseMode: unable to read %s", file_path)
             else:
                 logging.warning("PhaseMode: unable to read %s", file_path)
 

--- a/tests/test_phase_mode.py
+++ b/tests/test_phase_mode.py
@@ -172,9 +172,81 @@ class TestPhaseModeWorkflow(unittest.TestCase):
                 dispatcher._run_phase_mode(args)
 
             self.assertIn("hello", prompts[0])
+        self.assertEqual(
+            captured_cmds[0][captured_cmds[0].index("-C") + 1],
+            os.path.join(repo, "pkg"),
+        )
+
+    def test_phase_mode_phase_root_ee_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = os.path.join(tmp, "repo")
+            os.makedirs(os.path.join(repo, "ee", "pkg"), exist_ok=True)
+            src_rel = os.path.join("pkg", "src.txt")
+            src = os.path.join(repo, "ee", src_rel)
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("world")
+
+            findings = {
+                "vulnerabilities": [
+                    {"id": "v1", "file_path": src_rel, "severity": "low"}
+                ]
+            }
+            findings_path = os.path.join(tmp, "findings.json")
+            with open(findings_path, "w", encoding="utf-8") as fh:
+                json.dump(findings, fh)
+
+            listfile = os.path.join(tmp, "list.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(findings_path + "\n")
+
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                "--phase-mode",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--phase-root",
+                repo,
+                "-o",
+                outdir,
+                "-j",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_cmds: list[list[str]] = []
+            prompts: list[str] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [{"inquiry": "why"}, {"conclusion": "valid"}]
+
+            def fake_orchestrator(prompt, env=None):
+                prompts.append(prompt)
+                return orch_responses.pop(0)
+
+            with mock.patch("codexdispatch.dispatcher.find_codex_bin", return_value="codex"), \
+                mock.patch("codexdispatch.dispatcher._invoke_codex", side_effect=fake_invoke), \
+                mock.patch("codexdispatch.dispatcher.call_orchestrator", side_effect=fake_orchestrator):
+                dispatcher._run_phase_mode(args)
+
+            self.assertIn("world", prompts[0])
             self.assertEqual(
                 captured_cmds[0][captured_cmds[0].index("-C") + 1],
-                os.path.join(repo, "pkg"),
+                os.path.join(repo, "ee", "pkg"),
             )
 
 


### PR DESCRIPTION
## Summary
- add fallback to check `phase_root/ee/` when direct and phase-root lookups fail
- test phase-mode `ee` fallback path resolution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890804976ac832489315e9b0dbbc710