### PR TITLE
Streamline phase-mode conclusions and orchestrator guidance

### DIFF
--- a/codexdispatch/dispatcher.py
+++ b/codexdispatch/dispatcher.py
@@ -153,11 +153,13 @@ def call_orchestrator(prompt: str, env: dict[str, str] | None = None) -> dict:
             {
                 "role": "system",
                 "content": (
-                    "You are a security audit orchestrator. Use the"
-                    " orchestrator_decision function to either request"
-                    " further details or conclude whether the finding is"
-                    " valid or invalid. When concluding, provide a concise"
-                    " reasoning summary in the 'summary' field."
+                    "You are a security audit orchestrator. Always respond"
+                    " using the orchestrator_decision function. Ask the"
+                    " smallest, fastest-to-answer question that gives the"
+                    " most insight toward validating or invalidating the"
+                    " finding, and minimise the number of inquiries needed"
+                    " to reach a conclusion. When concluding, provide a"
+                    " concise reasoning summary in the 'summary' field."
                 ),
             },
             {"role": "user", "content": prompt},
@@ -183,6 +185,29 @@ def call_orchestrator(prompt: str, env: dict[str, str] | None = None) -> dict:
                     "conclusion": data["conclusion"],
                     "summary": data.get("summary", ""),
                 }
+
+        # Fallback: some models may return raw JSON instead of a tool call.
+        text = getattr(response, "output_text", "")
+        if not text:
+            for item in getattr(response, "output", []) or []:
+                if getattr(item, "type", None) == "message":
+                    for part in getattr(item, "content", []) or []:
+                        txt = getattr(part, "text", None)
+                        if txt:
+                            text += txt
+        if text:
+            try:
+                raw = json.loads(text.strip())
+            except json.JSONDecodeError:
+                raw = None
+            if isinstance(raw, dict):
+                if "inquiry" in raw:
+                    return {"inquiry": raw["inquiry"]}
+                if "conclusion" in raw:
+                    return {
+                        "conclusion": raw["conclusion"],
+                        "summary": raw.get("summary", ""),
+                    }
     finally:
         if old_env is not None:
             for k in env or {}:
@@ -485,6 +510,7 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
                 verdicts[vuln_id] = {
                     "file_path": file_path,
                     "conclusion": result.get("conclusion"),
+                    "summary": result.get("summary", ""),
                     "severity": severity,
                     "depth": depth,
                 }
@@ -538,11 +564,13 @@ def _run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> Non
             depth = len(context)
             final_path = os.path.join(final_dir, name)
             os.makedirs(os.path.dirname(final_path), exist_ok=True)
+            summary = "No conclusion: inquiry budget exhausted"
             with open(final_path, "w", encoding="utf-8") as fh:
-                json.dump({"conclusion": "inconclusive"}, fh)
+                json.dump({"conclusion": "inconclusive", "summary": summary}, fh)
             verdicts[vuln_id] = {
                 "file_path": file_path,
                 "conclusion": "inconclusive",
+                "summary": summary,
                 "severity": severity,
                 "depth": depth,
             }

--- a/orchestrator.txt
+++ b/orchestrator.txt
@@ -4,10 +4,11 @@ SYSTEM INSTRUCTIONS – FINDING-VALIDATION ORCHESTRATOR
 ROLE  
 • You are “RubySecure-Orchestrator-LLM”, a Socratic investigator that validates or falsifies security findings.
 
-OBJECTIVE  
-• For the supplied finding and Q&A history, decide either  
-  – the **next targeted follow-up question** needed to close a critical knowledge gap, or  
+OBJECTIVE
+• For the supplied finding and Q&A history, decide either
+  – the **next targeted follow-up question** needed to close a critical knowledge gap, or
   – a **final verdict** (`valid`, `invalid`, or `inconclusive`) when evidence is sufficient.
+• Minimize time to verdict: prefer questions that are fastest to answer yet highly informative, and conclude as soon as evidence allows.
 
 INPUTS  
 • finding_json   ⇢ auditor’s Phase 1 JSON (includes `vulnerabilities` & `logic_chain`).  
@@ -20,16 +21,18 @@ EVALUATION STRATEGY
    – authentication / authorization path  
    – environmental or configuration prerequisites  
    – exploit practicality or mitigation status  
-3. If **any high-impact assumption remains unverified**, craft the smallest, clearest question that—if answered—would most decisively confirm or refute the claim.  
-4. Otherwise, issue a **conclusion**:  
+3. If **any high-impact assumption remains unverified**, craft the smallest, clearest question that—if answered—would most decisively confirm or refute the claim.
+   The question should provide the most insight for the least analysis effort by the Codex agent.
+4. Otherwise, issue a **conclusion**:
    • `valid`   ↦ exploitable flaw convincingly demonstrated.  
    • `invalid`  ↦ claim disproved or fully mitigated.  
    • `inconclusive` ↦ evidence still ambiguous after max inquiries.
 
-INQUIRY RULES  
-• Reference concrete code context (file path + line numbers or specific logic_chain step).  
-• Request static evidence only—no dynamic tests, no external resources.  
-• Do **not** repeat prior questions; avoid broad or speculative wording.  
+INQUIRY RULES
+• Reference concrete code context (file path + line numbers or specific logic_chain step).
+• Request static evidence only—no dynamic tests, no external resources.
+• Do **not** repeat prior questions; avoid broad or speculative wording.
+• Choose inquiries requiring minimal effort while maximizing insight; always seek the shortest path to a verdict.
 
 OUTPUT SCHEMA (STRICT)
 


### PR DESCRIPTION
## Summary
- Encourage fast, insightful questioning in orchestrator prompt
- Parse raw JSON fallback and stress minimal inquiries in orchestrator system
- Record summaries when conclusions are reached or inquiry budget is exhausted

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68923acf852083249ff2d6a8818d4a3a