### PR TITLE
Create standalone phase-mode dispatcher

### DIFF
--- a/phase_mode/__init__.py
+++ b/phase_mode/__init__.py
@@ -1,0 +1,6 @@
+"""Phase mode only dispatcher package."""
+
+from .args import parse_args
+from .dispatcher import main, run_phase_mode
+
+__all__ = ["parse_args", "main", "run_phase_mode"]

--- a/phase_mode/args.py
+++ b/phase_mode/args.py
@@ -1,0 +1,84 @@
+"""Argument parser for phase mode dispatcher."""
+
+import argparse
+import os
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--audit-template",
+        dest="audit_template",
+        default=None,
+        help="path to the security-audit Codex template",
+    )
+    parser.add_argument(
+        "--orchestrator-template",
+        dest="orchestrator_template",
+        required=True,
+        help="path to the orchestrator chat-completion template",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--data-dir", dest="data_dir", help="directory containing input files")
+    group.add_argument(
+        "--tree-dirs",
+        nargs="+",
+        dest="tree_dirs",
+        help="directories to recursively walk",
+    )
+    group.add_argument(
+        "--file-list",
+        dest="file_list",
+        help="text file containing absolute/relative paths, one per line",
+    )
+    group.add_argument(
+        "--findings-list",
+        dest="findings_list",
+        help="text file containing paths to pre-supplied finding outputs",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        dest="output_dir",
+        required=True,
+        help="directory for dispatcher outputs",
+    )
+    parser.add_argument(
+        "--recursive",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="recursively walk tree directories",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(os.getenv("CODEX_DISPATCH_TIMEOUT", 900)),
+        help="per-file timeout in seconds (0 = none, default 900)",
+    )
+    parser.add_argument(
+        "--codex-bin",
+        dest="codex_bin",
+        default=None,
+        help="path to codex binary. Defaults to searching PATH or current directory",
+    )
+    parser.add_argument(
+        "--max-inquiries",
+        dest="max_inquiries",
+        type=int,
+        default=3,
+        help="cap on orchestrator and Codex iterations per finding",
+    )
+    parser.add_argument(
+        "--min-severity",
+        dest="min_severity",
+        choices=["low", "medium", "high", "critical"],
+        default=None,
+        help="minimum severity required for a vulnerability to be processed",
+    )
+    parser.add_argument(
+        "--phase-root",
+        dest="phase_root",
+        default=None,
+        help="top-level directory to resolve vulnerability file paths",
+    )
+    return parser.parse_args()

--- a/phase_mode/dispatcher.py
+++ b/phase_mode/dispatcher.py
@@ -1,0 +1,436 @@
+"""Dispatcher implementing phase mode only."""
+
+import hashlib
+import inspect
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+from typing import Dict, List, Optional
+
+import openai
+
+from .args import parse_args
+from .utils import collect_files, _invoke_codex, find_codex_bin, load_files
+from . import openai_stub
+
+MAX_RETRIES = 3
+BACKOFF_BASE = 2  # seconds
+
+
+
+def _retry_openai(req_fn, *args, **kwargs):
+    """Invoke `req_fn` with retries & back-off."""
+    fn_name = req_fn.__name__ if inspect.isfunction(req_fn) else repr(req_fn)
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            return req_fn(*args, **kwargs)
+        except (openai.OpenAIError, TypeError, RuntimeError) as err:
+            logging.error(
+                "OpenAI error in %s (try %d/%d): %s",
+                fn_name,
+                attempt,
+                MAX_RETRIES,
+                err,
+            )
+            if attempt == MAX_RETRIES:
+                logging.critical("Retries exhausted; aborting.")
+                raise
+            time.sleep(BACKOFF_BASE ** attempt)
+
+
+def _strip_backticks(text: str) -> str:
+    """Remove surrounding markdown code fences from ``text`` if present."""
+    stripped = text.strip()
+    if stripped.startswith("```") and stripped.endswith("```"):
+        lines = stripped.splitlines()
+        if lines:
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        return "\n".join(lines)
+    return text
+
+
+def _split_phase1_findings(phase1_dir: str) -> None:
+    """Split consolidated findings into one file per vulnerability."""
+    to_delete: list[str] = []
+    for dirpath, _, filenames in os.walk(phase1_dir):
+        for name in filenames:
+            path = os.path.join(dirpath, name)
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                continue
+            vulns = []
+            if isinstance(data, list):
+                vulns = data
+            elif isinstance(data, dict):
+                for key in ("vulnerabilities", "findings"):
+                    if isinstance(data.get(key), list):
+                        vulns = data[key]
+                        break
+                else:
+                    continue
+            else:
+                continue
+            for vuln in vulns:
+                vid = str(vuln.get("id")) if isinstance(vuln, dict) else None
+                if not vid:
+                    continue
+                orig = os.path.basename(vuln.get("file_path") or name)
+                out_name = f"{vid}_{orig}.json"
+                out_path = os.path.join(phase1_dir, out_name)
+                try:
+                    with open(out_path, "w", encoding="utf-8") as ofh:
+                        json.dump(vuln, ofh)
+                except OSError:
+                    continue
+            to_delete.append(path)
+    for path in to_delete:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    for dirpath, dirnames, filenames in os.walk(phase1_dir, topdown=False):
+        if dirpath == phase1_dir:
+            continue
+        if not dirnames and not filenames:
+            try:
+                os.rmdir(dirpath)
+            except OSError:
+                pass
+
+
+def call_orchestrator(prompt: str, env: dict[str, str] | None = None) -> dict:
+    """Return {"inquiry": "..."} or {"conclusion": "valid|invalid", "summary": "..."}."""
+    if env:
+        old_env = os.environ.copy()
+        os.environ.update(env)
+    else:
+        old_env = None
+    try:
+        schema = [
+            {
+                "name": "orchestrator_decision",
+                "description": "Ask for more information or conclude the audit.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "inquiry": {"type": "string"},
+                        "conclusion": {"type": "string", "enum": ["valid", "invalid"]},
+                        "summary": {"type": "string"},
+                    },
+                    "additionalProperties": False,
+                },
+            }
+        ]
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a security audit orchestrator. Always respond"
+                    " using the orchestrator_decision function."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+        try:
+            response = _retry_openai(
+                openai_stub.openai_generate_response,
+                messages=messages,
+                functions=schema,
+                model="o3",
+                reasoning_effort="high",
+                service_tier="flex",
+            )
+        except Exception:
+            raise
+        name, data = openai_stub.openai_parse_function_call(response)
+        if name == "orchestrator_decision" and isinstance(data, dict):
+            if "inquiry" in data:
+                return {"inquiry": data["inquiry"]}
+            if "conclusion" in data:
+                return {
+                    "conclusion": data["conclusion"],
+                    "summary": data.get("summary", ""),
+                }
+        text = getattr(response, "output_text", "")
+        if not text:
+            for item in getattr(response, "output", []) or []:
+                if getattr(item, "type", None) == "message":
+                    for part in getattr(item, "content", []) or []:
+                        txt = getattr(part, "text", None)
+                        if txt:
+                            text += txt
+        if text:
+            try:
+                raw = json.loads(text.strip())
+            except json.JSONDecodeError:
+                raw = {}
+            if "inquiry" in raw:
+                return {"inquiry": raw["inquiry"]}
+            if "conclusion" in raw:
+                return {
+                    "conclusion": raw.get("conclusion"),
+                    "summary": raw.get("summary", ""),
+                }
+    finally:
+        if old_env is not None:
+            os.environ.clear()
+            os.environ.update(old_env)
+    return {}
+
+
+def run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> None:
+    try:
+        with open(args.orchestrator_template, "r", encoding="utf-8") as f:
+            orchestrator_template = f.read()
+        if not args.findings_list:
+            with open(args.audit_template, "r", encoding="utf-8") as f:
+                audit_template = f.read()
+    except OSError as exc:
+        logging.error("PhaseMode: failed reading template: %s", exc)
+        return
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    codex_bin = find_codex_bin(args.codex_bin)
+
+    phase1_dir = os.path.join(args.output_dir, "phase_1")
+    final_dir = os.path.join(args.output_dir, "final")
+    os.makedirs(phase1_dir, exist_ok=True)
+    os.makedirs(final_dir, exist_ok=True)
+    cache_dir = os.path.join(os.path.dirname(os.path.abspath(args.output_dir)), "cache")
+    os.makedirs(cache_dir, exist_ok=True)
+    if args.findings_list:
+        try:
+            with open(args.findings_list, "r", encoding="utf-8") as fh:
+                raw = [l.strip() for l in fh if l.strip() and not l.strip().startswith("#")]
+        except OSError as exc:
+            logging.error("PhaseMode: failed reading findings list: %s", exc)
+            return
+        seen: set[str] = set()
+        inputs: List[str] = []
+        for p in raw:
+            if p not in seen:
+                seen.add(p)
+                inputs.append(p)
+        for src in inputs:
+            if not os.path.isfile(src):
+                logging.warning("PhaseMode: skipping missing finding %s", src)
+                continue
+            dest = os.path.join(phase1_dir, os.path.basename(src))
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            try:
+                shutil.copyfile(src, dest)
+            except OSError as exc:
+                logging.error("PhaseMode: failed copying %s: %s", src, exc)
+                continue
+    else:
+        if args.tree_dirs:
+            inputs = collect_files(args.tree_dirs, recursive=args.recursive)
+        elif args.data_dir:
+            inputs = load_files(args.data_dir)
+        elif args.file_list:
+            with open(args.file_list, "r", encoding="utf-8") as fh:
+                inputs = [p.strip() for p in fh if p.strip() and not p.strip().startswith("#")]
+        else:
+            inputs = []
+        inputs = sorted(dict.fromkeys(inputs))
+
+        for path in inputs:
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = f.read()
+            except UnicodeDecodeError:
+                logging.warning("PhaseMode: skipping non-text file %s", path)
+                continue
+            except OSError as exc:
+                logging.error("PhaseMode: failed reading %s: %s", path, exc)
+                continue
+            full_path = os.path.abspath(path)
+            prompt = f"{audit_template}\n{full_path}\n{data}"
+            rel_path = os.path.splitdrive(full_path)[1].lstrip(os.sep)
+            if not rel_path.endswith("-codex"):
+                rel_path = f"{rel_path}-codex"
+            out_path = os.path.join(phase1_dir, rel_path)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            cmd = [
+                codex_bin,
+                "exec",
+                "--output-last-message",
+                out_path,
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--skip-git-repo-check",
+                "-C",
+                os.path.dirname(path),
+            ]
+            logging.info("PhaseMode: phase_1 file=%s -> %s", path, out_path)
+            try:
+                _invoke_codex(cmd, prompt, args.timeout, path)
+            except subprocess.TimeoutExpired as te:
+                logging.error("TIMEOUT after %ss on %s", te.timeout, path)
+            except subprocess.CalledProcessError as cpe:
+                stderr = (cpe.stderr or b"").decode(errors="ignore")
+                logging.error("Codex exit %s on %s\n%s", cpe.returncode, path, stderr)
+            except Exception as exc:
+                logging.error("Failed processing %s: %s", path, exc)
+
+    _split_phase1_findings(phase1_dir)
+
+    verdicts: dict[str, dict] = {}
+
+    for name in sorted(f for f in os.listdir(phase1_dir) if f.endswith(".json")):
+        finding_path = os.path.join(phase1_dir, name)
+        try:
+            with open(finding_path, "r", encoding="utf-8") as fh:
+                finding_obj = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            logging.error("PhaseMode: failed reading %s: %s", finding_path, exc)
+            continue
+        if args.min_severity:
+            sev = finding_obj.get("severity")
+            ranks = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+            if sev is None or ranks.get(str(sev).lower(), -1) < ranks[args.min_severity]:
+                continue
+
+        vuln_id = str(finding_obj.get("id"))
+        file_path = finding_obj.get("file_path")
+        if not file_path:
+            logging.warning("PhaseMode: skipping vuln %s without file_path", vuln_id)
+            continue
+        severity = finding_obj.get("severity")
+        cache_key_src = f"{vuln_id}:{file_path}"
+        cache_key = hashlib.sha256(cache_key_src.encode()).hexdigest()
+        cache_path = os.path.join(cache_dir, f"{cache_key}.json")
+        cache_entry = {"context": [], "status": "open"}
+        if os.path.exists(cache_path):
+            try:
+                with open(cache_path, "r", encoding="utf-8") as cf:
+                    cache_entry = json.load(cf)
+            except (OSError, json.JSONDecodeError):
+                pass
+        if cache_entry.get("status") == "concluded":
+            continue
+        context = cache_entry.get("context", [])
+        source = ""
+        resolved_path = file_path
+        work_dir = os.path.dirname(os.path.abspath(resolved_path))
+        try:
+            with open(resolved_path, "r", encoding="utf-8") as sf:
+                source = sf.read()
+        except OSError:
+            if args.phase_root:
+                alt_path = os.path.join(args.phase_root, file_path)
+                try:
+                    with open(alt_path, "r", encoding="utf-8") as sf:
+                        source = sf.read()
+                        resolved_path = alt_path
+                        work_dir = os.path.dirname(os.path.abspath(resolved_path))
+                except OSError:
+                    ee_alt_path = os.path.join(args.phase_root, "ee", file_path)
+                    try:
+                        with open(ee_alt_path, "r", encoding="utf-8") as sf:
+                            source = sf.read()
+                            resolved_path = ee_alt_path
+                            work_dir = os.path.dirname(os.path.abspath(resolved_path))
+                    except OSError:
+                        logging.warning("PhaseMode: unable to read %s", file_path)
+            else:
+                logging.warning("PhaseMode: unable to read %s", file_path)
+
+        finding_json = json.dumps(finding_obj, indent=2)
+        concluded = False
+        for idx in range(len(context), args.max_inquiries):
+            prior_ctx = json.dumps(context, indent=2)
+            prompt = f"{orchestrator_template}\n{finding_json}\n{source}\n{prior_ctx}"
+            result = call_orchestrator(prompt, env=orchestrator_env)
+            if "conclusion" in result:
+                depth = len(context) + 1
+                final_path = os.path.join(final_dir, name)
+                os.makedirs(os.path.dirname(final_path), exist_ok=True)
+                with open(final_path, "w", encoding="utf-8") as fh:
+                    json.dump(result, fh)
+                verdicts[vuln_id] = {
+                    "file_path": file_path,
+                    "conclusion": result.get("conclusion"),
+                    "summary": result.get("summary", ""),
+                    "severity": severity,
+                    "depth": depth,
+                }
+                cache_entry = {"context": context, "status": "concluded"}
+                with open(cache_path, "w", encoding="utf-8") as cf:
+                    json.dump(cache_entry, cf)
+                concluded = True
+                break
+            inquiry = result.get("inquiry")
+            if not inquiry:
+                break
+            phase = idx + 2
+            out_path = os.path.join(args.output_dir, f"phase_{phase}", name)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            cmd = [
+                codex_bin,
+                "exec",
+                "--output-last-message",
+                out_path,
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--skip-git-repo-check",
+                "-C",
+                work_dir,
+            ]
+            try:
+                _invoke_codex(cmd, f"{finding_json}\n{inquiry}", args.timeout, finding_path)
+            except subprocess.TimeoutExpired as te:
+                logging.error("TIMEOUT after %ss on inquiry %s", te.timeout, finding_path)
+                break
+            except subprocess.CalledProcessError as cpe:
+                stderr = (cpe.stderr or b"").decode(errors="ignore")
+                logging.error("Codex exit %s on inquiry %s\n%s", cpe.returncode, finding_path, stderr)
+                break
+            except Exception as exc:
+                logging.error("Failed inquiry %s: %s", finding_path, exc)
+                break
+            try:
+                with open(out_path, "r", encoding="utf-8") as rf:
+                    response = rf.read()
+            except OSError:
+                response = ""
+            with open(out_path + ".meta", "w", encoding="utf-8") as mf:
+                json.dump({"inquiry": inquiry, "response": response}, mf)
+            context.append({"inquiry": inquiry, "response": response})
+            cache_entry = {"context": context, "status": "open"}
+            with open(cache_path, "w", encoding="utf-8") as cf:
+                json.dump(cache_entry, cf)
+        if not concluded and cache_entry.get("status") != "concluded":
+            depth = len(context)
+            final_path = os.path.join(final_dir, name)
+            os.makedirs(os.path.dirname(final_path), exist_ok=True)
+            summary = "No conclusion: inquiry budget exhausted"
+            with open(final_path, "w", encoding="utf-8") as fh:
+                json.dump({"conclusion": "inconclusive", "summary": summary}, fh)
+            verdicts[vuln_id] = {
+                "file_path": file_path,
+                "conclusion": "inconclusive",
+                "summary": summary,
+                "severity": severity,
+                "depth": depth,
+            }
+            cache_entry = {"context": context, "status": "concluded"}
+            with open(cache_path, "w", encoding="utf-8") as cf:
+                json.dump(cache_entry, cf)
+
+    if verdicts:
+        os.makedirs(final_dir, exist_ok=True)
+        verdict_path = os.path.join(final_dir, "verdicts.json")
+        with open(verdict_path, "w", encoding="utf-8") as vf:
+            json.dump(verdicts, vf)
+
+
+
+def main() -> None:
+    args = parse_args()
+    run_phase_mode(args)

--- a/phase_mode/openai_stub.py
+++ b/phase_mode/openai_stub.py
@@ -1,0 +1,88 @@
+"""Thin wrapper around the OpenAI client used by phase mode."""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+_client = None
+
+
+def openai_configure_api(api_key: Optional[str] = None):
+    """Retrieve key, build global client, log success."""
+    global _client
+    if _client is not None:
+        return _client
+    try:
+        from openai import OpenAI
+    except Exception as exc:  # pragma: no cover - import failure path
+        logging.warning("openai package not available: %s", exc)
+        return None
+    key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        logging.warning("OPENAI_API_KEY is not set")
+        return None
+    _client = OpenAI(api_key=key)
+    logging.info("OpenAI client configured")
+    return _client
+
+
+def openai_generate_response(
+    *,
+    messages: List[Dict[str, str]],
+    functions: Optional[List[Dict[str, Any]]] = None,
+    function_call: Optional[str | Dict[str, str]] = "auto",
+    model: str = "o3",
+    reasoning_effort: str = "high",
+    service_tier: str = "flex",
+    **extra: Any,
+):
+    """Wrapper around ``client.responses.create`` with defaults."""
+    client = openai_configure_api()
+    if client is None:
+        raise RuntimeError("OpenAI client is not configured")
+
+    tools: List[Dict[str, Any]] = [{"type": "web_search"}]
+    if functions:
+        tools.extend({"type": "function", **f} for f in functions)
+
+    params: Dict[str, Any] = {
+        "model": model,
+        "input": messages,
+        "tools": tools,
+        "reasoning": {"effort": reasoning_effort},
+        "service_tier": service_tier,
+        **extra,
+    }
+
+    logging.info("Sending:\n%s", messages)
+    response = client.responses.create(**params)
+    logging.info("Received:\n%s", response)
+    return response
+
+
+def openai_parse_function_call(response: Any) -> Tuple[Optional[str], Any]:
+    """Extract function call data from a Responses API result."""
+    fc = None
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) in {"function_call", "tool_call"}:
+            fc = item
+            break
+    if not fc:
+        output = getattr(response, "output", None)
+        msg = output[0] if output else None
+        content = getattr(msg, "content", []) if msg else []
+        for item in content:
+            if getattr(item, "type", None) == "tool_call":
+                fc = item
+                break
+    if not fc:
+        return None, None
+    name = getattr(fc, "name", None)
+    args_str = getattr(fc, "arguments", "") or "{}"
+    try:
+        data = json.loads(args_str)
+    except json.JSONDecodeError:
+        data = {}
+    logging.info("Function call %s with %s", name, data)
+    return name, data

--- a/phase_mode/utils.py
+++ b/phase_mode/utils.py
@@ -1,0 +1,93 @@
+# Utility helpers for phase mode dispatcher
+"""Utility helpers for phase mode dispatcher."""
+"""Utility helpers for phase mode dispatcher."""
+
+
+"""Utility helpers for phase mode dispatcher."""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from typing import Optional
+
+
+def load_files(data_dir: str) -> list[str]:
+    """Return a sorted list of file paths under *data_dir*."""
+    return sorted(
+        [
+            os.path.join(dp, f)
+            for dp, _, filenames in os.walk(data_dir)
+            for f in filenames
+            if os.path.isfile(os.path.join(dp, f))
+        ]
+    )
+
+
+def collect_files(dirs: list[str], recursive: bool = True) -> list[str]:
+    files: list[str] = []
+    for root in dirs:
+        if recursive:
+            for dirpath, _, filenames in os.walk(root):
+                for name in filenames:
+                    path = os.path.join(dirpath, name)
+                    if os.path.isfile(path):
+                        files.append(path)
+        else:
+            for name in os.listdir(root):
+                path = os.path.join(root, name)
+                if os.path.isfile(path):
+                    files.append(path)
+    return sorted(files)
+
+
+def find_codex_bin(path_hint: Optional[str]) -> str:
+    """Return the path to the codex binary."""
+    if path_hint:
+        codex_path = os.path.abspath(path_hint)
+        if not os.path.exists(codex_path):
+            logging.error("Codex binary not found at %s", codex_path)
+            sys.exit(1)
+        return codex_path
+
+    codex_bin = shutil.which("codex")
+    if codex_bin is not None:
+        return codex_bin
+
+    candidates = [
+        f
+        for f in os.listdir(os.getcwd())
+        if os.path.isfile(f) and "codex" in f and os.access(f, os.X_OK)
+    ]
+    if len(candidates) == 1:
+        return os.path.abspath(candidates[0])
+    if len(candidates) > 1:
+        logging.error(
+            "Multiple codex binaries found in current directory: %s",
+            ", ".join(candidates),
+        )
+        sys.exit(1)
+
+    logging.error("Codex binary not found in PATH or current directory")
+    sys.exit(1)
+
+
+def _invoke_codex(cmd: list[str], prompt: str, timeout: Optional[int], path: str) -> None:
+    """Invoke codex process with retries."""
+    max_tries = 2
+    for attempt in range(1, max_tries + 1):
+        try:
+            subprocess.run(
+                cmd,
+                input=prompt.encode(),
+                check=True,
+                timeout=timeout or None,
+                stderr=subprocess.PIPE,
+            )
+            break
+        except subprocess.TimeoutExpired:
+            if attempt == max_tries:
+                raise
+            logging.warning("Retrying (%s/%s) %s", attempt, max_tries, path)

--- a/tests/test_phase_mode_only.py
+++ b/tests/test_phase_mode_only.py
@@ -1,0 +1,244 @@
+import os
+import sys
+import json
+import hashlib
+import tempfile
+import unittest
+import unittest.mock as mock
+
+import phase_mode as dispatch
+import phase_mode.dispatcher as dispatcher
+
+
+class TestPhaseModeOnly(unittest.TestCase):
+    def test_phase_mode_split_and_verdicts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src.txt")
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("source")
+
+            findings = {
+                "vulnerabilities": [
+                    {"id": "v1", "file_path": src, "severity": "low"},
+                    {"id": "v2", "file_path": src, "severity": "high"},
+                ]
+            }
+            findings_path = os.path.join(tmp, "findings.json")
+            with open(findings_path, "w", encoding="utf-8") as fh:
+                json.dump(findings, fh)
+
+            listfile = os.path.join(tmp, "list.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(findings_path + "\n")
+
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "-o",
+                outdir,
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_cmds: list[list[str]] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [
+                {"conclusion": "valid", "summary": "ok"},
+                {"inquiry": "why"},
+                {"conclusion": "invalid", "summary": "no"},
+            ]
+
+            prompts: list[str] = []
+
+            def fake_orchestrator(prompt, env=None):
+                prompts.append(prompt)
+                return orch_responses.pop(0)
+
+            with mock.patch("phase_mode.dispatcher.find_codex_bin", return_value="codex"), \
+                mock.patch("phase_mode.dispatcher._invoke_codex", side_effect=fake_invoke), \
+                mock.patch("phase_mode.dispatcher.call_orchestrator", side_effect=fake_orchestrator):
+                dispatcher.run_phase_mode(args)
+
+            phase1_dir = os.path.join(outdir, "phase_1")
+            v1_file = os.path.join(phase1_dir, f"v1_{os.path.basename(src)}.json")
+            v2_file = os.path.join(phase1_dir, f"v2_{os.path.basename(src)}.json")
+            self.assertTrue(os.path.exists(v1_file))
+            self.assertTrue(os.path.exists(v2_file))
+
+            cache_dir = os.path.join(tmp, "cache")
+            key = hashlib.sha256(f"v2:{src}".encode()).hexdigest()
+            self.assertTrue(os.path.exists(os.path.join(cache_dir, f"{key}.json")))
+
+            verdicts_path = os.path.join(outdir, "final", "verdicts.json")
+            with open(verdicts_path, "r", encoding="utf-8") as vf:
+                verdicts = json.load(vf)
+            self.assertEqual(verdicts["v1"]["conclusion"], "valid")
+            self.assertEqual(verdicts["v2"]["conclusion"], "invalid")
+
+            phase2 = os.path.join(outdir, "phase_2", os.path.basename(v2_file))
+            self.assertTrue(os.path.exists(phase2))
+
+            self.assertIn("-C", captured_cmds[0])
+            self.assertEqual(
+                captured_cmds[0][captured_cmds[0].index("-C") + 1], os.path.dirname(src)
+            )
+
+            self.assertIn("source", prompts[0])
+
+    def test_phase_mode_phase_root_resolution(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = os.path.join(tmp, "repo")
+            os.makedirs(os.path.join(repo, "pkg"), exist_ok=True)
+            src_rel = os.path.join("pkg", "src.txt")
+            src = os.path.join(repo, src_rel)
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("hello")
+
+            findings = {
+                "vulnerabilities": [
+                    {"id": "v1", "file_path": src_rel, "severity": "low"}
+                ]
+            }
+            findings_path = os.path.join(tmp, "findings.json")
+            with open(findings_path, "w", encoding="utf-8") as fh:
+                json.dump(findings, fh)
+
+            listfile = os.path.join(tmp, "list.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(findings_path + "\n")
+
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--phase-root",
+                repo,
+                "-o",
+                outdir,
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_cmds: list[list[str]] = []
+            prompts: list[str] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [{"inquiry": "why"}, {"conclusion": "valid"}]
+
+            def fake_orchestrator(prompt, env=None):
+                prompts.append(prompt)
+                return orch_responses.pop(0)
+
+            with mock.patch("phase_mode.dispatcher.find_codex_bin", return_value="codex"), \
+                mock.patch("phase_mode.dispatcher._invoke_codex", side_effect=fake_invoke), \
+                mock.patch("phase_mode.dispatcher.call_orchestrator", side_effect=fake_orchestrator):
+                dispatcher.run_phase_mode(args)
+
+            self.assertIn("hello", prompts[0])
+            self.assertEqual(
+                captured_cmds[0][captured_cmds[0].index("-C") + 1],
+                os.path.join(repo, "pkg"),
+            )
+
+    def test_phase_mode_phase_root_ee_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = os.path.join(tmp, "repo")
+            os.makedirs(os.path.join(repo, "ee", "pkg"), exist_ok=True)
+            src_rel = os.path.join("pkg", "src.txt")
+            src = os.path.join(repo, "ee", src_rel)
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("world")
+
+            findings = {
+                "vulnerabilities": [
+                    {"id": "v1", "file_path": src_rel, "severity": "low"}
+                ]
+            }
+            findings_path = os.path.join(tmp, "findings.json")
+            with open(findings_path, "w", encoding="utf-8") as fh:
+                json.dump(findings, fh)
+
+            listfile = os.path.join(tmp, "list.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(findings_path + "\n")
+
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "--phase-root",
+                repo,
+                "-o",
+                outdir,
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_cmds: list[list[str]] = []
+            prompts: list[str] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [{"inquiry": "why"}, {"conclusion": "valid"}]
+
+            def fake_orchestrator(prompt, env=None):
+                prompts.append(prompt)
+                return orch_responses.pop(0)
+
+            with mock.patch("phase_mode.dispatcher.find_codex_bin", return_value="codex"), \
+                mock.patch("phase_mode.dispatcher._invoke_codex", side_effect=fake_invoke), \
+                mock.patch("phase_mode.dispatcher.call_orchestrator", side_effect=fake_orchestrator):
+                dispatcher.run_phase_mode(args)
+
+            self.assertIn("world", prompts[0])
+            self.assertEqual(
+                captured_cmds[0][captured_cmds[0].index("-C") + 1],
+                os.path.join(repo, "ee", "pkg"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- provide `phase_mode` package containing argument parsing, dispatcher, utils, and OpenAI stub for phase-mode-only workflows
- add tests verifying phase-mode split and orchestrator verdict logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68924d996a7083248d2beb73f9b23633