### PR TITLE
Add phase mode entry point

### DIFF
--- a/combine_traces.py
+++ b/combine_traces.py
@@ -1,0 +1,74 @@
+"""Utility to combine paramtrace and new finding traces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Dict, Set
+
+
+def _load_paramtrace(path: str) -> Dict[str, Set[str]]:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    mapping: Dict[str, Set[str]] = {}
+    for entry in data:
+        method = entry.get("method")
+        if not method:
+            continue
+        for trace in entry.get("trace", []):
+            file_path = str(trace).split(":", 1)[0]
+            mapping.setdefault(method, set()).add(file_path)
+    return mapping
+
+
+def _load_newfindings(path: str) -> Dict[str, Set[str]]:
+    mapping: Dict[str, Set[str]] = {}
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            method = entry.get("method")
+            if not method:
+                continue
+            for trace in entry.get("trace", []):
+                mapping.setdefault(method, set()).add(trace)
+    return mapping
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paramtrace", required=True, help="path to paramtrace JSON file")
+    parser.add_argument("--newfindings", required=True, help="path to new findings JSONL file")
+    parser.add_argument("--output-dir", required=True, help="directory to write combined outputs")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    combined: Dict[str, Set[str]] = {}
+    pt_map = _load_paramtrace(args.paramtrace)
+    nf_map = _load_newfindings(args.newfindings)
+    for method, paths in pt_map.items():
+        combined.setdefault(method, set()).update(paths)
+    for method, paths in nf_map.items():
+        combined.setdefault(method, set()).update(paths)
+
+    for method, paths in combined.items():
+        out_name = method.replace(".", "_") + ".txt"
+        out_path = os.path.join(args.output_dir, out_name)
+        with open(out_path, "w", encoding="utf-8") as out:
+            for p in sorted(paths):
+                try:
+                    with open(p, "r", encoding="utf-8") as fh:
+                        out.write(fh.read())
+                except OSError:
+                    continue
+
+
+if __name__ == "__main__":
+    main()

--- a/copy_gem_methods.py
+++ b/copy_gem_methods.py
@@ -1,0 +1,36 @@
+"""Utilities for copying gem methods based on parsed marker files."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+
+def resolve_paths_from_parsed(focused_dir: str, parsed_dir: str) -> List[str]:
+    """Return file paths under ``focused_dir`` corresponding to markers in ``parsed_dir``.
+
+    The parsed directory may contain ``*.parsed.json`` marker files under arbitrary
+    subdirectories. Each marker mirrors the path of a Ruby source file located under
+    ``focused_dir``. This function translates those markers back to real source
+    paths and only returns ones that actually exist.
+    """
+    resolved: List[str] = []
+    for root, _, files in os.walk(parsed_dir):
+        for name in files:
+            if not name.endswith(".parsed.json"):
+                continue
+            marker_path = os.path.join(root, name)
+            rel = os.path.relpath(marker_path, parsed_dir)
+            parts = rel.split(os.sep)
+            try:
+                idx = parts.index("gem")
+            except ValueError:
+                continue
+            rel_parts = parts[idx:]
+            rel_parts[-1] = rel_parts[-1].removesuffix(".parsed.json")
+            candidate = os.path.join(focused_dir, *rel_parts)
+            if os.path.exists(candidate):
+                resolved.append(candidate)
+    return resolved
+
+__all__ = ["resolve_paths_from_parsed"]

--- a/phase_mode/__main__.py
+++ b/phase_mode/__main__.py
@@ -1,0 +1,6 @@
+"""CLI entry point for the phase mode dispatcher."""
+
+from .dispatcher import main
+
+if __name__ == "__main__":
+    main()

--- a/prompts/security_audit_generic.txt
+++ b/prompts/security_audit_generic.txt
@@ -1,0 +1,71 @@
+\====================================
+SYSTEM INSTRUCTIONS – RUBY CODEBASE AUDITOR (REFINED)
+=====================================================
+
+ROLE
+• You are **“RubySecure-Audit-LLM”**, a read-only static-analysis assistant.
+
+OBJECTIVE
+• Audit the **Ruby codebase in the current GitLab repository**, beginning with the *entry file* (the file that triggered the audit).
+• Discover and report **any high-impact security-relevant logic flaws**, without relying on a fixed bug-class checklist.
+• Deliver results strictly in the JSON format defined under **“OUTPUT SCHEMA”**, with a linear step-by-step explanation embedded in each vulnerability object.
+
+TRAVERSAL RULE – INTEGRATION BOUNDARY
+• Start at the entry file.
+• You may inspect **any repository file** provided you have a *causal reason* linked to the entry file or to findings in previously reviewed files (e.g., data flow, control flow, shared state, or API interaction).
+• Stay within the repository; never fetch external resources or execute code.
+
+VULNERABILITY DISCOVERY PRINCIPLES
+• **Infer** potential weaknesses from the code’s intent, data-flow, and trust boundaries.
+• Prioritise flaws that could yield **novel, severe impact** (remote compromise, privilege escalation, critical data corruption, etc.).
+• Ignore trivial, fully mitigated, or low-impact issues.
+
+DELIVERABLE – OUTPUT SCHEMA (STRICT)
+
+```json
+{
+  "entry_file": "<string – relative path>",
+  "files_scanned": ["<string>", ...],
+  "git_commit": "<string – short SHA or null>",
+  "audit_timestamp_utc": "<ISO-8601>",
+  "vulnerabilities": [
+    {
+      "id": "VULN-001",
+      "name": "<short title>",
+      "description": "<concise explanation>",
+      "impact": "<brief impact statement>",
+      "severity": "critical|high|medium|low",
+      "confidence": 0.0,
+      "file_path": "<string>",
+      "line_start": 0,
+      "line_end": 0,
+      "code_excerpt": "<escaped snippet>",
+      "recommendation": "<single actionable fix>",
+      "steps": [
+        {
+          "file_path": "<string>",
+          "line_start": 0,
+          "line_end": 0,
+          "deduction": "<why these lines matter and how they lead to a potential flaw>"
+        }
+        /* …additional steps… */
+      ]
+    }
+    /* …more objects… */
+  ],
+  "stats": {
+    "total_vulnerabilities": 0,
+    "highest_severity": "none|low|medium|high|critical",
+    "analysis_duration_ms": 0
+  }
+}
+```
+
+WHEN NO ISSUES FOUND
+• Return the same JSON with `"vulnerabilities": []` and `"highest_severity": "none"`.
+
+VALIDATION
+• Output must be valid JSON matching the schema exactly—no comments, prose, markdown, or tool metadata.
+Put the JSON object alone on the final line, no trailing text.
+Add “No markdown fences” to constraints.
+


### PR DESCRIPTION
## Summary
- allow running the phase mode dispatcher directly via `python -m phase_mode`
- add helper to resolve Ruby gem source paths from parsed markers
- add script to merge paramtrace and new finding traces
- provide default security audit prompt template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893236e09148324890b9f5174eef113