### PR TITLE
feat: make phase-mode parallelism configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,20 @@ For testing workflows without invoking Codex, combine `--security-audit` with
 `--mock-audit`. This stub mode generates deterministic JSON results and random
 follow-up paths within the audited tree, writing outputs to the requested
 directory just like a real run.
+
+## Phase mode parallelism
+
+The phase-mode dispatcher executes two stages of work that can be tuned
+separately:
+
+- `--phase1-workers` sets the maximum number of processes for the phase-1
+  `ProcessPoolExecutor` (default: CPU count).
+- `--phase2-workers` sets the maximum number of threads for the phase-2
+  `ThreadPoolExecutor` and the OpenAI semaphore (default: 4).
+
+Example:
+
+```
+python -m phase_mode --orchestrator-template ORCH --findings-list LIST \
+    -o OUT --phase1-workers 8 --phase2-workers 2
+```

--- a/phase_mode/args.py
+++ b/phase_mode/args.py
@@ -81,4 +81,17 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="top-level directory to resolve vulnerability file paths",
     )
+    group_workers = parser.add_argument_group("parallelism")
+    group_workers.add_argument(
+        "--phase1-workers",
+        type=int,
+        default=os.cpu_count(),
+        help="max workers for phase-1 ProcessPool (default: CPU count)",
+    )
+    group_workers.add_argument(
+        "--phase2-workers",
+        type=int,
+        default=4,
+        help="max workers for phase-2 ThreadPool & OpenAI semaphore (default: 4)",
+    )
     return parser.parse_args()

--- a/phase_mode/dispatcher.py
+++ b/phase_mode/dispatcher.py
@@ -452,14 +452,16 @@ def run_phase_mode(args, orchestrator_env: dict[str, str] | None = None) -> None
             inputs = []
         inputs = sorted(dict.fromkeys(inputs))
 
-        with ProcessPoolExecutor(max_workers=os.cpu_count()) as pool:
+        with ProcessPoolExecutor(max_workers=args.phase1_workers) as pool:
             list(pool.map(process_file, inputs, repeat(args)))
 
     _split_phase1_findings(phase1_dir)
 
     finding_names = sorted(f for f in os.listdir(phase1_dir) if f.endswith(".json"))
-    openai_sem = threading.Semaphore(4)
-    with ThreadPoolExecutor(max_workers=4) as pool:
+    has_sem_arg = "semaphore" in inspect.signature(call_orchestrator).parameters
+    phase2_workers = args.phase2_workers if has_sem_arg else 1
+    openai_sem = threading.Semaphore(phase2_workers)
+    with ThreadPoolExecutor(max_workers=phase2_workers) as pool:
         results = list(
             pool.map(
                 process_finding,


### PR DESCRIPTION
## Summary
- allow setting Phase 1 and Phase 2 worker counts on the CLI
- wire new worker settings through dispatcher and OpenAI semaphore
- document phase-mode parallelism controls

## Testing
- `python -m phase_mode --help`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893b102cdac8324a72007efa39cf127