### PR TITLE
feat: force final orchestrator decision before marking inconclusive

### DIFF
--- a/phase_mode/dispatcher.py
+++ b/phase_mode/dispatcher.py
@@ -376,8 +376,32 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
         _atomic_write_json(out_path + ".meta", {"inquiry": inquiry, "response": response})
         context.append({"inquiry": inquiry, "response": response})
         _atomic_write_json(cache_path, {"context": context, "status": "open"})
+    # Exhausted inquiry budget; make one final attempt to conclude.
+    prior_ctx = json.dumps(context, indent=2)
+    final_prompt = (
+        f"{args.orchestrator_template_text}\n{finding_json}\n{source}\n{prior_ctx}\n"
+        "Based on the available information, provide a definitive conclusion"
+        " ('valid' or 'invalid') and a concise summary."
+    )
+    try:
+        result = call_orchestrator(final_prompt, env=orchestrator_env, semaphore=semaphore)
+    except TypeError:
+        result = call_orchestrator(final_prompt, env=orchestrator_env)
+    if "conclusion" in result:
+        depth = len(context) + 1
+        final_path = os.path.join(final_dir, name)
+        _atomic_write_json(final_path, result)
+        verdict = {
+            "file_path": file_path,
+            "conclusion": result.get("conclusion"),
+            "summary": result.get("summary", ""),
+            "severity": severity,
+            "depth": depth,
+        }
+        _atomic_write_json(cache_path, {"context": context, "status": "concluded"})
+        return {vuln_id: verdict}
 
-    depth = len(context)
+    depth = len(context) + 1
     final_path = os.path.join(final_dir, name)
     summary = "No conclusion: inquiry budget exhausted"
     _atomic_write_json(final_path, {"conclusion": "inconclusive", "summary": summary})

--- a/tests/test_phase_mode_only.py
+++ b/tests/test_phase_mode_only.py
@@ -240,5 +240,133 @@ class TestPhaseModeOnly(unittest.TestCase):
             )
 
 
+    def test_phase_mode_forced_final_conclusion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src.txt")
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("source")
+
+            findings = {"vulnerabilities": [{"id": "v1", "file_path": src, "severity": "low"}]}
+            findings_path = os.path.join(tmp, "findings.json")
+            with open(findings_path, "w", encoding="utf-8") as fh:
+                json.dump(findings, fh)
+
+            listfile = os.path.join(tmp, "list.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(findings_path + "\n")
+
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "-o",
+                outdir,
+                "--max-inquiries",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_cmds: list[list[str]] = []
+            prompts: list[str] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [{"inquiry": "why"}, {"conclusion": "valid", "summary": "ok"}]
+
+            def fake_orchestrator(prompt, env=None):
+                prompts.append(prompt)
+                return orch_responses.pop(0)
+
+            with mock.patch("phase_mode.dispatcher.find_codex_bin", return_value="codex"), \
+                mock.patch("phase_mode.dispatcher._invoke_codex", side_effect=fake_invoke), \
+                mock.patch("phase_mode.dispatcher.call_orchestrator", side_effect=fake_orchestrator):
+                dispatcher.run_phase_mode(args)
+
+            verdicts_path = os.path.join(outdir, "final", "verdicts.json")
+            with open(verdicts_path, "r", encoding="utf-8") as vf:
+                verdicts = json.load(vf)
+            self.assertEqual(verdicts["v1"]["conclusion"], "valid")
+            self.assertEqual(verdicts["v1"]["depth"], 2)
+            self.assertEqual(len(prompts), 2)
+            self.assertEqual(len(captured_cmds), 1)
+
+
+    def test_phase_mode_forced_inconclusive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src.txt")
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("source")
+
+            findings = {"vulnerabilities": [{"id": "v1", "file_path": src, "severity": "low"}]}
+            findings_path = os.path.join(tmp, "findings.json")
+            with open(findings_path, "w", encoding="utf-8") as fh:
+                json.dump(findings, fh)
+
+            listfile = os.path.join(tmp, "list.txt")
+            with open(listfile, "w", encoding="utf-8") as fh:
+                fh.write(findings_path + "\n")
+
+            orch = os.path.join(tmp, "orch.txt")
+            with open(orch, "w", encoding="utf-8") as fh:
+                fh.write("orch")
+
+            outdir = os.path.join(tmp, "out")
+            os.mkdir(outdir)
+
+            argv = [
+                "dispatch.py",
+                "--orchestrator-template",
+                orch,
+                "--findings-list",
+                listfile,
+                "-o",
+                outdir,
+                "--max-inquiries",
+                "1",
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = dispatch.parse_args()
+
+            captured_cmds: list[list[str]] = []
+            prompts: list[str] = []
+
+            def fake_invoke(cmd, prompt, timeout, path):
+                captured_cmds.append(list(cmd))
+                out = cmd[cmd.index("--output-last-message") + 1]
+                with open(out, "w", encoding="utf-8") as fh:
+                    fh.write("resp")
+
+            orch_responses = [{"inquiry": "why"}, {}]
+
+            def fake_orchestrator(prompt, env=None):
+                prompts.append(prompt)
+                return orch_responses.pop(0)
+
+            with mock.patch("phase_mode.dispatcher.find_codex_bin", return_value="codex"), \
+                mock.patch("phase_mode.dispatcher._invoke_codex", side_effect=fake_invoke), \
+                mock.patch("phase_mode.dispatcher.call_orchestrator", side_effect=fake_orchestrator):
+                dispatcher.run_phase_mode(args)
+
+            verdicts_path = os.path.join(outdir, "final", "verdicts.json")
+            with open(verdicts_path, "r", encoding="utf-8") as vf:
+                verdicts = json.load(vf)
+            self.assertEqual(verdicts["v1"]["conclusion"], "inconclusive")
+            self.assertEqual(verdicts["v1"]["depth"], 2)
+            self.assertEqual(len(prompts), 2)
+            self.assertEqual(len(captured_cmds), 1)
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- after exhausting inquiry budget, issue a final orchestrator call using full context and request a definitive conclusion
- mark inconclusive only if the extra call fails and bump the recorded depth
- add tests for forced final conclusions and forced inconclusive outcomes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893bc682ab483248b69416908c20244