### PR TITLE
Preserve model summary for inconclusive findings

### DIFF
--- a/phase_mode/dispatcher.py
+++ b/phase_mode/dispatcher.py
@@ -387,9 +387,9 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
         result = call_orchestrator(final_prompt, env=orchestrator_env, semaphore=semaphore)
     except TypeError:
         result = call_orchestrator(final_prompt, env=orchestrator_env)
+    depth = len(context) + 1
+    final_path = os.path.join(final_dir, name)
     if "conclusion" in result:
-        depth = len(context) + 1
-        final_path = os.path.join(final_dir, name)
         _atomic_write_json(final_path, result)
         verdict = {
             "file_path": file_path,
@@ -401,14 +401,11 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
         _atomic_write_json(cache_path, {"context": context, "status": "concluded"})
         return {vuln_id: verdict}
 
-    depth = len(context) + 1
-    final_path = os.path.join(final_dir, name)
-    summary = "No conclusion: inquiry budget exhausted"
-    _atomic_write_json(final_path, {"conclusion": "inconclusive", "summary": summary})
+    _atomic_write_json(final_path, result)
     verdict = {
         "file_path": file_path,
-        "conclusion": "inconclusive",
-        "summary": summary,
+        "conclusion": result.get("conclusion", "inconclusive"),
+        "summary": result.get("summary", "").strip() or "Model returned no summary.",
         "severity": severity,
         "depth": depth,
     }

--- a/tests/test_phase_mode_only.py
+++ b/tests/test_phase_mode_only.py
@@ -350,7 +350,7 @@ class TestPhaseModeOnly(unittest.TestCase):
                 with open(out, "w", encoding="utf-8") as fh:
                     fh.write("resp")
 
-            orch_responses = [{"inquiry": "why"}, {}]
+            orch_responses = [{"inquiry": "why"}, {"summary": "ran out"}]
 
             def fake_orchestrator(prompt, env=None):
                 prompts.append(prompt)
@@ -365,6 +365,7 @@ class TestPhaseModeOnly(unittest.TestCase):
             with open(verdicts_path, "r", encoding="utf-8") as vf:
                 verdicts = json.load(vf)
             self.assertEqual(verdicts["v1"]["conclusion"], "inconclusive")
+            self.assertEqual(verdicts["v1"]["summary"], "ran out")
             self.assertEqual(verdicts["v1"]["depth"], 2)
             self.assertEqual(len(prompts), 2)
             self.assertEqual(len(captured_cmds), 1)


### PR DESCRIPTION
## Summary
- Store orchestrator output even when no definitive conclusion is provided
- Mark verdicts as `inconclusive` while keeping the model's summary text
- Extend unit test to verify summary is preserved for inconclusive verdicts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893bf7d17c88324b7c32e39e814ce3f