### PR TITLE
Include vulnerability details in phase mode results

### DIFF
--- a/phase_mode/dispatcher.py
+++ b/phase_mode/dispatcher.py
@@ -330,13 +330,19 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
         if "conclusion" in result:
             depth = len(context) + 1
             final_path = os.path.join(final_dir, name)
-            _atomic_write_json(final_path, result)
+            final_out = {
+                "vulnerability": finding_obj,
+                "conclusion": result.get("conclusion"),
+                "summary": result.get("summary", ""),
+            }
+            _atomic_write_json(final_path, final_out)
             verdict = {
                 "file_path": file_path,
                 "conclusion": result.get("conclusion"),
                 "summary": result.get("summary", ""),
                 "severity": severity,
                 "depth": depth,
+                "vulnerability": finding_obj,
             }
             _atomic_write_json(cache_path, {"context": context, "status": "concluded"})
             return {vuln_id: verdict}
@@ -390,24 +396,35 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
     depth = len(context) + 1
     final_path = os.path.join(final_dir, name)
     if "conclusion" in result:
-        _atomic_write_json(final_path, result)
+        final_out = {
+            "vulnerability": finding_obj,
+            "conclusion": result.get("conclusion"),
+            "summary": result.get("summary", ""),
+        }
+        _atomic_write_json(final_path, final_out)
         verdict = {
             "file_path": file_path,
             "conclusion": result.get("conclusion"),
             "summary": result.get("summary", ""),
             "severity": severity,
             "depth": depth,
+            "vulnerability": finding_obj,
         }
         _atomic_write_json(cache_path, {"context": context, "status": "concluded"})
         return {vuln_id: verdict}
 
-    _atomic_write_json(final_path, result)
+    final_out = {
+        "vulnerability": finding_obj,
+        **result,
+    }
+    _atomic_write_json(final_path, final_out)
     verdict = {
         "file_path": file_path,
         "conclusion": result.get("conclusion", "inconclusive"),
         "summary": result.get("summary", "").strip() or "Model returned no summary.",
         "severity": severity,
         "depth": depth,
+        "vulnerability": finding_obj,
     }
     _atomic_write_json(cache_path, {"context": context, "status": "concluded"})
     return {vuln_id: verdict}

--- a/tests/test_phase_mode_only.py
+++ b/tests/test_phase_mode_only.py
@@ -90,6 +90,14 @@ class TestPhaseModeOnly(unittest.TestCase):
                 verdicts = json.load(vf)
             self.assertEqual(verdicts["v1"]["conclusion"], "valid")
             self.assertEqual(verdicts["v2"]["conclusion"], "invalid")
+            self.assertEqual(verdicts["v1"]["vulnerability"]["id"], "v1")
+            self.assertEqual(verdicts["v2"]["vulnerability"]["id"], "v2")
+
+            final_v1 = os.path.join(outdir, "final", os.path.basename(v1_file))
+            with open(final_v1, "r", encoding="utf-8") as ff:
+                final_obj = json.load(ff)
+            self.assertEqual(final_obj["vulnerability"]["id"], "v1")
+            self.assertEqual(final_obj["conclusion"], "valid")
 
             phase2 = os.path.join(outdir, "phase_2", os.path.basename(v2_file))
             self.assertTrue(os.path.exists(phase2))


### PR DESCRIPTION
## Summary
- Add original vulnerability object to per-finding final results
- Preserve the original finding within `verdicts.json`
- Test that final outputs carry vulnerability metadata alongside verdicts

## Testing
- `pytest tests/test_phase_mode_only.py::TestPhaseModeOnly::test_phase_mode_split_and_verdicts -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893c9ec25688324b3d9b15e5575e7b6