### PR TITLE
Add compatibility mode correlating findings with vulnerabilities

### DIFF
--- a/compat_mode.py
+++ b/compat_mode.py
@@ -1,0 +1,114 @@
+"""Backwards compatibility mode to correlate findings with vulnerabilities."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--findings-dir",
+        dest="findings_dir",
+        required=True,
+        help="directory containing findings JSON files",
+    )
+    parser.add_argument(
+        "--vuln-dir",
+        dest="vuln_dir",
+        required=True,
+        help="directory containing original vulnerability JSON files",
+    )
+    parser.add_argument(
+        "--phase-root",
+        dest="phase_root",
+        default=None,
+        help="base directory to resolve file_path entries",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        dest="output_dir",
+        required=True,
+        help="directory for correlated outputs",
+    )
+    return parser.parse_args()
+
+
+def _load_json(path: str) -> dict | None:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def run_compat_mode(args: argparse.Namespace) -> None:
+    os.makedirs(args.output_dir, exist_ok=True)
+    summary: Dict[str, Dict[str, dict]] = {}
+
+    for name in sorted(os.listdir(args.findings_dir)):
+        if not name.endswith(".json"):
+            continue
+        finding_path = os.path.join(args.findings_dir, name)
+        finding_obj = _load_json(finding_path)
+        if not finding_obj:
+            continue
+        vuln_id = finding_obj.get("id") or name.split("_", 1)[0]
+
+        vuln_path = None
+        for vname in os.listdir(args.vuln_dir):
+            if vname.startswith(vuln_id):
+                vuln_path = os.path.join(args.vuln_dir, vname)
+                break
+        if not vuln_path:
+            continue
+        vuln_obj = _load_json(vuln_path)
+        if not vuln_obj:
+            continue
+
+        file_path = vuln_obj.get("file_path")
+        source = ""
+        resolved_path = file_path
+        if file_path:
+            candidates = []
+            if os.path.isabs(file_path):
+                candidates.append(file_path)
+            if args.phase_root:
+                candidates.append(os.path.join(args.phase_root, file_path))
+                candidates.append(os.path.join(args.phase_root, "ee", file_path))
+            for candidate in candidates:
+                try:
+                    with open(candidate, "r", encoding="utf-8") as sf:
+                        source = sf.read()
+                        resolved_path = candidate
+                        break
+                except OSError:
+                    continue
+        vuln_obj["file_path"] = resolved_path
+
+        out_obj = {
+            "summary": finding_obj,
+            "vulnerability": vuln_obj,
+            "source": source,
+        }
+        out_path = os.path.join(args.output_dir, name)
+        with open(out_path, "w", encoding="utf-8") as ofh:
+            json.dump(out_obj, ofh)
+
+        summary[vuln_id] = {"summary": finding_obj, "vulnerability": vuln_obj}
+
+    summary_path = os.path.join(args.output_dir, "findings_summary.json")
+    with open(summary_path, "w", encoding="utf-8") as sf:
+        json.dump(summary, sf)
+
+
+def main() -> None:
+    args = parse_args()
+    run_compat_mode(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_compat_mode.py
+++ b/tests/test_compat_mode.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import json
+import tempfile
+import unittest
+import unittest.mock as mock
+
+import compat_mode
+
+
+class TestCompatMode(unittest.TestCase):
+    def test_correlate_and_resolve(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            findings_dir = os.path.join(tmp, "findings")
+            vulns_dir = os.path.join(tmp, "vulns")
+            repo = os.path.join(tmp, "repo")
+            outdir = os.path.join(tmp, "out")
+            os.makedirs(findings_dir)
+            os.makedirs(vulns_dir)
+            os.makedirs(repo)
+            os.makedirs(outdir)
+
+            # source file
+            src_rel = os.path.join("pkg", "src.txt")
+            src_abs = os.path.join(repo, src_rel)
+            os.makedirs(os.path.dirname(src_abs), exist_ok=True)
+            with open(src_abs, "w", encoding="utf-8") as fh:
+                fh.write("hello")
+
+            vuln_obj = {"id": "VULN-001", "file_path": src_rel}
+            vuln_path = os.path.join(vulns_dir, "VULN-001.json")
+            with open(vuln_path, "w", encoding="utf-8") as fh:
+                json.dump(vuln_obj, fh)
+
+            finding_obj = {"id": "VULN-001", "summary": "issue"}
+            finding_path = os.path.join(findings_dir, "VULN-001_pkg_src.txt.json")
+            with open(finding_path, "w", encoding="utf-8") as fh:
+                json.dump(finding_obj, fh)
+
+            argv = [
+                "prog",
+                "--findings-dir",
+                findings_dir,
+                "--vuln-dir",
+                vulns_dir,
+                "--phase-root",
+                repo,
+                "-o",
+                outdir,
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                args = compat_mode.parse_args()
+            compat_mode.run_compat_mode(args)
+
+            out_file = os.path.join(outdir, "VULN-001_pkg_src.txt.json")
+            with open(out_file, "r", encoding="utf-8") as fh:
+                out_obj = json.load(fh)
+            self.assertEqual(out_obj["vulnerability"]["id"], "VULN-001")
+            self.assertEqual(out_obj["vulnerability"]["file_path"], src_abs)
+            self.assertIn("hello", out_obj["source"])
+            self.assertEqual(out_obj["summary"]["summary"], "issue")
+
+            summary_file = os.path.join(outdir, "findings_summary.json")
+            with open(summary_file, "r", encoding="utf-8") as fh:
+                summary = json.load(fh)
+            self.assertIn("VULN-001", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `compat_mode` to map existing finding files to vulnerability definitions and source content
- store per-vulnerability output and summary JSON for backwards compatibility
- add unit test for compatibility mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e9a6458c8324b86fd077b09222a1