### PR TITLE
Add batch search mode for forced web search

### DIFF
--- a/batch_search.py
+++ b/batch_search.py
@@ -1,0 +1,57 @@
+"""Batch search mode: send files to OpenAI with forced web search."""
+
+import argparse
+import json
+import os
+
+from openai import OpenAI
+
+
+def batch_search(input_dir: str, output_dir: str, model: str = "gpt-4o") -> None:
+    """Send contents of files in ``input_dir`` to OpenAI and write responses.
+
+    Each file's content is passed to the Responses API with web search forced
+    via ``tool_choice``. Results are written to ``output_dir`` using the
+    original filename with ``_response.json`` appended.
+    """
+
+    client = OpenAI()
+    os.makedirs(output_dir, exist_ok=True)
+
+    for filename in os.listdir(input_dir):
+        in_path = os.path.join(input_dir, filename)
+        if not os.path.isfile(in_path):
+            continue
+
+        with open(in_path, "r", encoding="utf-8") as f:
+            text = f.read()
+
+        response = client.responses.create(
+            model=model,
+            input=text,
+            tools=[{"type": "web_search"}],
+            tool_choice={"type": "web_search"},
+        )
+
+        out_filename = f"{os.path.splitext(filename)[0]}_response.json"
+        out_path = os.path.join(output_dir, out_filename)
+
+        with open(out_path, "w", encoding="utf-8") as out_f:
+            json.dump(response, out_f, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Batch web search using OpenAI")
+    parser.add_argument("input_dir", help="Directory containing input files")
+    parser.add_argument("output_dir", help="Directory to write responses")
+    parser.add_argument("--model", default="gpt-4o", help="Model name to use")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    batch_search(args.input_dir, args.output_dir, model=args.model)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_batch_search.py
+++ b/tests/test_batch_search.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from unittest import mock
+
+import batch_search
+
+
+def test_batch_search_forces_web_search(tmp_path):
+    input_dir = tmp_path / "in"
+    output_dir = tmp_path / "out"
+    input_dir.mkdir()
+    (input_dir / "a.txt").write_text("hello")
+    (input_dir / "b.txt").write_text("world")
+
+    captured = []
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            captured.append(kwargs)
+            return {"result": "ok"}
+
+    fake_client = mock.MagicMock()
+    fake_client.responses = FakeResponses()
+
+    with mock.patch("batch_search.OpenAI", return_value=fake_client):
+        batch_search.batch_search(str(input_dir), str(output_dir))
+
+    # Ensure two files processed
+    assert len(captured) == 2
+    # Ensure tool forcing
+    for kwargs in captured:
+        assert kwargs["tools"] == [{"type": "web_search"}]
+        assert kwargs["tool_choice"] == {"type": "web_search"}
+    # Ensure outputs written
+    assert (output_dir / "a_response.json").is_file()
+    assert (output_dir / "b_response.json").is_file()


### PR DESCRIPTION
## Summary
- add `batch_search` script that iterates over a directory of files, forces web search via the OpenAI Responses API, and writes JSON outputs per file
- add tests ensuring the mode forces the `web_search` tool choice and produces response files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ed7024a083248d3d9a403b8581fd