### PR TITLE
Add file source info to final verdicts

### DIFF
--- a/phase_mode/dispatcher.py
+++ b/phase_mode/dispatcher.py
@@ -77,6 +77,16 @@ def _atomic_write_json(path: str, data: dict) -> None:
     os.replace(tmp_name, target)
 
 
+def _trim_source_text(text: str) -> str:
+    """Trim large source files to first and last 200 lines."""
+    if len(text.encode("utf-8")) <= 100 * 1024:
+        return text
+    lines = text.splitlines()
+    head = lines[:200]
+    tail = lines[-200:] if len(lines) > 200 else []
+    return "\n".join(head + ["..."] + tail)
+
+
 def _split_phase1_findings(phase1_dir: str) -> None:
     """Split consolidated findings into one file per vulnerability."""
     to_delete: list[str] = []
@@ -318,6 +328,11 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
         else:
             logging.warning("PhaseMode: unable to read %s", file_path)
 
+    file_source = {
+        "path": os.path.abspath(resolved_path),
+        "contents": _trim_source_text(source),
+    }
+
     finding_json = json.dumps(finding_obj, indent=2)
     concluded = False
     for idx in range(len(context), args.max_inquiries):
@@ -332,6 +347,7 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
             final_path = os.path.join(final_dir, name)
             final_out = {
                 "vulnerability": finding_obj,
+                "file_source": file_source,
                 "conclusion": result.get("conclusion"),
                 "summary": result.get("summary", ""),
             }
@@ -398,6 +414,7 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
     if "conclusion" in result:
         final_out = {
             "vulnerability": finding_obj,
+            "file_source": file_source,
             "conclusion": result.get("conclusion"),
             "summary": result.get("summary", ""),
         }
@@ -415,6 +432,7 @@ def process_finding(name: str, args, orchestrator_env: dict[str, str] | None, se
 
     final_out = {
         "vulnerability": finding_obj,
+        "file_source": file_source,
         **result,
     }
     _atomic_write_json(final_path, final_out)

--- a/tests/test_file_source.py
+++ b/tests/test_file_source.py
@@ -1,0 +1,63 @@
+import json
+import os
+import tempfile
+import threading
+import unittest
+import unittest.mock as mock
+from types import SimpleNamespace
+
+import phase_mode.dispatcher as dispatcher
+
+
+class TestFileSource(unittest.TestCase):
+    def test_process_finding_includes_file_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src.py")
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("print('hi')\n")
+
+            phase1 = os.path.join(tmp, "phase1")
+            final = os.path.join(tmp, "final")
+            cache = os.path.join(tmp, "cache")
+            os.makedirs(phase1, exist_ok=True)
+            os.makedirs(final, exist_ok=True)
+            os.makedirs(cache, exist_ok=True)
+
+            finding = {"id": "v1", "file_path": src, "severity": "low"}
+            name = "finding.json"
+            with open(os.path.join(phase1, name), "w", encoding="utf-8") as fh:
+                json.dump(finding, fh)
+
+            args = SimpleNamespace(
+                phase1_dir=phase1,
+                final_dir=final,
+                cache_dir=cache,
+                min_severity=None,
+                phase_root=None,
+                orchestrator_template_text="orch",
+                max_inquiries=1,
+                timeout=10,
+                codex_bin="codex",
+                output_dir=tmp,
+            )
+
+            with mock.patch(
+                "phase_mode.dispatcher.call_orchestrator",
+                return_value={"conclusion": "valid", "summary": "ok"},
+            ):
+                dispatcher.process_finding(
+                    name, args, orchestrator_env=None, semaphore=threading.Semaphore()
+                )
+
+            final_path = os.path.join(final, name)
+            with open(final_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+
+            self.assertIn("file_source", data)
+            self.assertEqual(data["file_source"]["path"], os.path.abspath(src))
+            self.assertTrue(data["file_source"]["contents"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- include `file_source` (path and contents) in phase-mode final verdict JSONs
- trim stored source text when files exceed 100KiB
- test that `process_finding` writes `file_source` with path and contents

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893fb90cfc483249c9c7ecbbe2be1bb