### PR TITLE
Add script using OpenAI web search tool

### DIFF
--- a/search_directory.py
+++ b/search_directory.py
@@ -1,0 +1,63 @@
+"""Script to process files with OpenAI using web_search tool."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Dict, Any
+
+from openai import OpenAI
+
+
+def run_on_directory(input_dir: str, template: str, client: OpenAI | None = None) -> Dict[str, Any]:
+    """Send each file's contents to the OpenAI API with a system template.
+
+    Args:
+        input_dir: Directory containing text files to process.
+        template: Template to prepend as a system message.
+        client: Optional OpenAI client. A new client is created if not provided.
+
+    Returns:
+        Mapping of file name to raw response objects.
+    """
+    if client is None:
+        client = OpenAI()
+
+    responses: Dict[str, Any] = {}
+    for name in sorted(os.listdir(input_dir)):
+        path = os.path.join(input_dir, name)
+        if not os.path.isfile(path):
+            continue
+        with open(path, "r", encoding="utf-8") as fh:
+            content = fh.read()
+        messages = [
+            {"role": "system", "content": template},
+            {"role": "user", "content": content},
+        ]
+        response = client.responses.create(
+            model="gpt-4o",
+            input=messages,
+            tools=[{"type": "web_search"}],
+            tool_choice={"type": "web_search"},
+        )
+        responses[name] = response
+    return responses
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run OpenAI web search over files in a directory")
+    parser.add_argument("input_dir", help="Directory containing input files")
+    parser.add_argument(
+        "template_file",
+        help="Path to file whose contents will be used as the system template",
+    )
+    args = parser.parse_args()
+
+    with open(args.template_file, "r", encoding="utf-8") as tf:
+        template = tf.read()
+
+    run_on_directory(args.input_dir, template)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_search_directory.py
+++ b/tests/test_search_directory.py
@@ -1,0 +1,37 @@
+import types
+
+import search_directory
+
+
+class FakeResponses:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return types.SimpleNamespace(output=[types.SimpleNamespace(content=[])])
+
+
+class FakeClient:
+    def __init__(self):
+        self.responses = FakeResponses()
+
+
+def test_run_on_directory_calls_openai_with_web_search(tmp_path):
+    # Prepare input file and template
+    inp = tmp_path / "file.txt"
+    inp.write_text("hello")
+    template = "You are helpful"
+
+    client = FakeClient()
+    result = search_directory.run_on_directory(str(tmp_path), template, client)
+
+    assert "file.txt" in result
+    call = client.responses.calls[0]
+    assert call["model"] == "gpt-4o"
+    assert call["tools"] == [{"type": "web_search"}]
+    assert call["tool_choice"] == {"type": "web_search"}
+
+    messages = call["input"]
+    assert messages[0] == {"role": "system", "content": template}
+    assert messages[1] == {"role": "user", "content": "hello"}


### PR DESCRIPTION
## Summary
- Add `search_directory.py` script to send files through OpenAI's `gpt-4o` model using the `web_search` tool, with a CLI entry point
- Test that the script forces use of `web_search` via `tool_choice`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689408a4caac83248eb2e82ad306ba4a