### PR TITLE
Handle non-serializable OpenAI responses

### DIFF
--- a/search_directory.py
+++ b/search_directory.py
@@ -51,13 +51,21 @@ def run_on_directory(
             tools=[{"type": "web_search"}],
             tool_choice={"type": "web_search"},
         )
-        responses[name] = response
+
+        # The OpenAI client returns a pydantic model which isn't JSON serializable
+        # by default. Some test doubles may instead return plain dictionaries, so
+        # gracefully handle both cases.
+        if hasattr(response, "model_dump"):
+            serializable = response.model_dump()
+        else:
+            serializable = response
+        responses[name] = serializable
 
         if output_dir is not None:
             out_name = f"{os.path.splitext(name)[0]}_response.json"
             out_path = os.path.join(output_dir, out_name)
             with open(out_path, "w", encoding="utf-8") as out_f:
-                json.dump(response, out_f, indent=2)
+                json.dump(serializable, out_f, indent=2)
     return responses
 
 


### PR DESCRIPTION
## Summary
- Convert `search_directory.run_on_directory` output to handle OpenAI response objects not directly JSON serializable
- Support both Pydantic models and plain dictionaries when writing response JSON

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689410bf09248324828c2888b17daa4b