### PR TITLE
Default to o3 model with flex service tier and text output

### DIFF
--- a/batch_search.py
+++ b/batch_search.py
@@ -1,18 +1,38 @@
 """Batch search mode: send files to OpenAI with forced web search."""
 
 import argparse
-import json
 import os
+from typing import Any
 
 from openai import OpenAI
 
 
-def batch_search(input_dir: str, output_dir: str, model: str = "gpt-4o") -> None:
+def _extract_output_text(response: Any) -> str:
+    text = getattr(response, "output_text", "")
+    if text:
+        return text
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) == "message":
+            for part in getattr(item, "content", []) or []:
+                txt = getattr(part, "text", None)
+                if txt:
+                    text += txt
+    if not text and isinstance(response, dict):
+        for item in response.get("output", []) or []:
+            if item.get("type") == "message":
+                for part in item.get("content", []) or []:
+                    txt = part.get("text")
+                    if txt:
+                        text += txt
+    return text
+
+
+def batch_search(input_dir: str, output_dir: str, model: str = "o3") -> None:
     """Send contents of files in ``input_dir`` to OpenAI and write responses.
 
     Each file's content is passed to the Responses API with web search forced
     via ``tool_choice``. Results are written to ``output_dir`` using the
-    original filename with ``_response.json`` appended.
+    original filename with ``_response.txt`` appended.
     """
 
     client = OpenAI()
@@ -31,20 +51,23 @@ def batch_search(input_dir: str, output_dir: str, model: str = "gpt-4o") -> None
             input=text,
             tools=[{"type": "web_search"}],
             tool_choice={"type": "web_search"},
+            service_tier="flex",
+            reasoning={"effort": "high"},
         )
+        output_text = _extract_output_text(response)
 
-        out_filename = f"{os.path.splitext(filename)[0]}_response.json"
+        out_filename = f"{os.path.splitext(filename)[0]}_response.txt"
         out_path = os.path.join(output_dir, out_filename)
 
         with open(out_path, "w", encoding="utf-8") as out_f:
-            json.dump(response, out_f, indent=2)
+            out_f.write(output_text)
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Batch web search using OpenAI")
     parser.add_argument("input_dir", help="Directory containing input files")
     parser.add_argument("output_dir", help="Directory to write responses")
-    parser.add_argument("--model", default="gpt-4o", help="Model name to use")
+    parser.add_argument("--model", default="o3", help="Model name to use")
     return parser.parse_args()
 
 

--- a/search_directory.py
+++ b/search_directory.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
-from typing import Any, Dict
+from typing import Dict
 
 from openai import OpenAI
 
@@ -15,18 +14,18 @@ def run_on_directory(
     template: str,
     output_dir: str | None = None,
     client: OpenAI | None = None,
-) -> Dict[str, Any]:
+) -> Dict[str, str]:
     """Send each file's contents to the OpenAI API with a system template.
 
     Args:
         input_dir: Directory containing text files to process.
         template: Template to prepend as a system message.
         output_dir: If provided, responses are written to this directory as
-            ``<filename>_response.json``.
+            ``<filename>_response.txt``.
         client: Optional OpenAI client. A new client is created if not provided.
 
     Returns:
-        Mapping of file name to raw response objects.
+        Mapping of file name to response text.
     """
     if client is None:
         client = OpenAI()
@@ -34,7 +33,7 @@ def run_on_directory(
     if output_dir is not None:
         os.makedirs(output_dir, exist_ok=True)
 
-    responses: Dict[str, Any] = {}
+    responses: Dict[str, str] = {}
     for name in sorted(os.listdir(input_dir)):
         path = os.path.join(input_dir, name)
         if not os.path.isfile(path):
@@ -46,26 +45,29 @@ def run_on_directory(
             {"role": "user", "content": content},
         ]
         response = client.responses.create(
-            model="gpt-4o",
+            model="o3",
             input=messages,
             tools=[{"type": "web_search"}],
             tool_choice={"type": "web_search"},
+            service_tier="flex",
+            reasoning={"effort": "high"},
         )
 
-        # The OpenAI client returns a pydantic model which isn't JSON serializable
-        # by default. Some test doubles may instead return plain dictionaries, so
-        # gracefully handle both cases.
-        if hasattr(response, "model_dump"):
-            serializable = response.model_dump()
-        else:
-            serializable = response
-        responses[name] = serializable
+        text = getattr(response, "output_text", "")
+        if not text:
+            for item in getattr(response, "output", []) or []:
+                if getattr(item, "type", None) == "message":
+                    for part in getattr(item, "content", []) or []:
+                        txt = getattr(part, "text", None)
+                        if txt:
+                            text += txt
+        responses[name] = text
 
         if output_dir is not None:
-            out_name = f"{os.path.splitext(name)[0]}_response.json"
+            out_name = f"{os.path.splitext(name)[0]}_response.txt"
             out_path = os.path.join(output_dir, out_name)
             with open(out_path, "w", encoding="utf-8") as out_f:
-                json.dump(serializable, out_f, indent=2)
+                out_f.write(text)
     return responses
 
 
@@ -78,7 +80,7 @@ def main() -> None:
     )
     parser.add_argument(
         "output_dir",
-        help="Directory to write response JSON files",
+        help="Directory to write response text files",
     )
     args = parser.parse_args()
 

--- a/tests/test_batch_search.py
+++ b/tests/test_batch_search.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from unittest import mock
 
@@ -31,6 +30,9 @@ def test_batch_search_forces_web_search(tmp_path):
     for kwargs in captured:
         assert kwargs["tools"] == [{"type": "web_search"}]
         assert kwargs["tool_choice"] == {"type": "web_search"}
+        assert kwargs["model"] == "o3"
+        assert kwargs["service_tier"] == "flex"
+        assert kwargs["reasoning"] == {"effort": "high"}
     # Ensure outputs written
-    assert (output_dir / "a_response.json").is_file()
-    assert (output_dir / "b_response.json").is_file()
+    assert (output_dir / "a_response.txt").is_file()
+    assert (output_dir / "b_response.txt").is_file()

--- a/tests/test_search_directory.py
+++ b/tests/test_search_directory.py
@@ -31,7 +31,9 @@ def test_run_on_directory_calls_openai_with_web_search(tmp_path):
 
     assert "file.txt" in result
     call = client.responses.calls[0]
-    assert call["model"] == "gpt-4o"
+    assert call["model"] == "o3"
+    assert call["service_tier"] == "flex"
+    assert call["reasoning"] == {"effort": "high"}
     assert call["tools"] == [{"type": "web_search"}]
     assert call["tool_choice"] == {"type": "web_search"}
 
@@ -51,7 +53,7 @@ def test_run_on_directory_writes_output(tmp_path):
         str(input_dir), "template", output_dir=str(output_dir), client=client
     )
 
-    out_file = output_dir / "a_response.json"
+    out_file = output_dir / "a_response.txt"
     assert out_file.is_file()
-    data = json.loads(out_file.read_text())
-    assert data == {"output": [{"content": []}]}
+    data = out_file.read_text()
+    assert data == ""


### PR DESCRIPTION
## Summary
- Default search utilities to OpenAI's `o3` model and include high-effort reasoning with flex service tier.
- Parse Responses API results to store only the assistant's final text in `_response.txt` files.
- Update tests to validate the new defaults and output format.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894144f4bf483248c0af06c084cc8a5